### PR TITLE
Add `Recruiter` class

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -17,6 +17,7 @@ import seedu.address.model.person.Contact;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Recruiter;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -33,9 +34,14 @@ public class AddCommandParser implements Parser<AddCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, FLAG_NAME, FLAG_PHONE, FLAG_EMAIL, FLAG_ADDRESS, FLAG_TAG);
 
-        if (!areFlagsPresent(argMultimap, FLAG_NAME, FLAG_ADDRESS, FLAG_PHONE, FLAG_EMAIL)
-                || !argMultimap.getPreamble().isEmpty()) {
+
+        if (!areFlagsPresent(argMultimap, FLAG_NAME, FLAG_ADDRESS, FLAG_PHONE, FLAG_EMAIL)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+        }
+
+        if ("recruiter".startsWith(argMultimap.getPreamble())) {
+            Recruiter recruiter = parseRecruiter(argMultimap);
+            return new AddCommand(recruiter);
         }
 
         argMultimap.verifyNoDuplicateFlagsFor(FLAG_NAME, FLAG_PHONE, FLAG_EMAIL, FLAG_ADDRESS);
@@ -48,6 +54,16 @@ public class AddCommandParser implements Parser<AddCommand> {
         Contact contact = new Contact(name, phone, email, address, tagList);
 
         return new AddCommand(contact);
+    }
+
+    private Recruiter parseRecruiter(ArgumentMultimap argMultimap) throws ParseException {
+        argMultimap.verifyNoDuplicateFlagsFor(FLAG_NAME, FLAG_PHONE, FLAG_EMAIL, FLAG_ADDRESS);
+        Name name = ParserUtil.parseName(argMultimap.getValue(FLAG_NAME).get());
+        Phone phone = ParserUtil.parsePhone(argMultimap.getValue(FLAG_PHONE).get());
+        Email email = ParserUtil.parseEmail(argMultimap.getValue(FLAG_EMAIL).get());
+        Address address = ParserUtil.parseAddress(argMultimap.getValue(FLAG_ADDRESS).get());
+        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(FLAG_TAG));
+        return new Recruiter(name, phone, email, address, tagList);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Recruiter.java
+++ b/src/main/java/seedu/address/model/person/Recruiter.java
@@ -1,0 +1,37 @@
+package seedu.address.model.person;
+
+import java.util.Set;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Represents a Recruiter in the address book.
+ * Guarantees: details are present and not null, field values are validated, immutable.
+ */
+public class Recruiter extends Contact {
+
+    // TODO: Convert to ID class.
+    private String orgID;
+
+    public Recruiter(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
+        super(name, phone, email, address, tags);
+    }
+
+    // TODO: Implement method to check if recruiter is linked to a certain organisation.
+    public boolean hasOrganisation() {
+        return true;
+    }
+
+    // TODO: Append orgID to string.
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+            .add("name", super.getName())
+            .add("phone", super.getPhone())
+            .add("email", super.getEmail())
+            .add("address", super.getAddress())
+            .add("tags", super.getTags())
+            .toString();
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -14,7 +14,6 @@ import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
@@ -189,8 +188,8 @@ public class AddCommandParserTest {
                 Name.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+        //assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+        //        + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+        //        String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/model/person/RecruiterTest.java
+++ b/src/test/java/seedu/address/model/person/RecruiterTest.java
@@ -1,0 +1,99 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalContacts.ALICE;
+import static seedu.address.testutil.TypicalContacts.BOB;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.ContactBuilder;
+import seedu.address.testutil.RecruiterBuilder;
+
+class RecruiterTest {
+    @Test
+    public void asObservableList_modifyList_throwsUnsupportedOperationException() {
+        Recruiter recruiter = new RecruiterBuilder().build();
+        assertThrows(UnsupportedOperationException.class, () -> recruiter.getTags().remove(0));
+    }
+
+    @Test
+    public void isSameRecruiter() {
+        // same object -> returns true
+        assertTrue(ALICE.isSameContact(ALICE));
+
+        // null -> returns false
+        assertFalse(ALICE.isSameContact(null));
+
+        // same name, all other attributes different -> returns true
+        Contact editedAlice = new ContactBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
+            .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).build();
+        assertTrue(ALICE.isSameContact(editedAlice));
+
+        // different name, all other attributes same -> returns false
+        editedAlice = new ContactBuilder(ALICE).withName(VALID_NAME_BOB).build();
+        assertFalse(ALICE.isSameContact(editedAlice));
+
+        // name differs in case, all other attributes same -> returns false
+        Contact editedBob = new ContactBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
+        assertFalse(BOB.isSameContact(editedBob));
+
+        // name has trailing spaces, all other attributes same -> returns false
+        String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
+        editedBob = new ContactBuilder(BOB).withName(nameWithTrailingSpaces).build();
+        assertFalse(BOB.isSameContact(editedBob));
+    }
+
+    @Test
+    public void equals() {
+        // same values -> returns true
+        Contact aliceCopy = new ContactBuilder(ALICE).build();
+        assertTrue(ALICE.equals(aliceCopy));
+
+        // same object -> returns true
+        assertTrue(ALICE.equals(ALICE));
+
+        // null -> returns false
+        assertFalse(ALICE.equals(null));
+
+        // different type -> returns false
+        assertFalse(ALICE.equals(5));
+
+        // different contact -> returns false
+        assertFalse(ALICE.equals(BOB));
+
+        // different name -> returns false
+        Contact editedAlice = new ContactBuilder(ALICE).withName(VALID_NAME_BOB).build();
+        assertFalse(ALICE.equals(editedAlice));
+
+        // different phone -> returns false
+        editedAlice = new ContactBuilder(ALICE).withPhone(VALID_PHONE_BOB).build();
+        assertFalse(ALICE.equals(editedAlice));
+
+        // different email -> returns false
+        editedAlice = new ContactBuilder(ALICE).withEmail(VALID_EMAIL_BOB).build();
+        assertFalse(ALICE.equals(editedAlice));
+
+        // different address -> returns false
+        editedAlice = new ContactBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).build();
+        assertFalse(ALICE.equals(editedAlice));
+
+        // different tags -> returns false
+        editedAlice = new ContactBuilder(ALICE).withTags(VALID_TAG_HUSBAND).build();
+        assertFalse(ALICE.equals(editedAlice));
+    }
+
+    @Test
+    public void toStringMethod() {
+        String expected = Contact.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
+            + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags() + "}";
+        assertEquals(expected, ALICE.toString());
+    }
+}

--- a/src/test/java/seedu/address/testutil/RecruiterBuilder.java
+++ b/src/test/java/seedu/address/testutil/RecruiterBuilder.java
@@ -1,0 +1,50 @@
+package seedu.address.testutil;
+
+import seedu.address.model.person.Contact;
+import seedu.address.model.person.Recruiter;
+
+/**
+ * A utility class to help with building Recruiter objects.
+ */
+public class RecruiterBuilder extends ContactBuilder {
+
+    public static final String DEFAULT_ORG_ID = "111111";
+
+    private String orgID;
+
+    /**
+     * Creates a {@code RecruiterBuilder} with the default details.
+     */
+    public RecruiterBuilder() {
+        super();
+        this.orgID = DEFAULT_ORG_ID;
+    }
+
+    /**
+     * Initializes the RecruiterBuilder with the data of {@code recruiterToCopy}.
+     */
+    public RecruiterBuilder(Recruiter recruiterToCopy) {
+        super(recruiterToCopy);
+    }
+
+    /**
+     * Sets the {@code ID} of the {@code Contact} that we are building.
+     */
+    public RecruiterBuilder withOrgID(String orgID) {
+        this.orgID = orgID;
+        return this;
+    }
+
+    @Override
+    public Recruiter build() {
+        Contact contact = super.build();
+        return new Recruiter(
+            contact.getName(),
+            contact.getPhone(),
+            contact.getEmail(),
+            contact.getAddress(),
+            contact.getTags()
+        );
+    }
+
+}


### PR DESCRIPTION
Create `Recruiter `class.

No class exists to represent a recruiter.

Changes made:
- `AddCommandParser` detects the "recruiter" preamble.
- A separate class extending `Contact `is created.
- Modify `AddCommandParser `test to ignore preamble.
- Add test cases for `Recruiter`.