### PR TITLE
Overhaul argument tokenization to be generic

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -18,11 +18,14 @@ public class Messages {
     public static final String MESSAGE_NO_SUCH_CONTACT = "No such contact";
     public static final String MESSAGE_CONTACTS_LISTED_OVERVIEW = "%1$d contacts listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
-            "Multiple values specified for the following single-valued field(s): ";
+            "Multiple values specified for the following single-valued option(s): ";
     public static final String MESSAGE_EXTRA_FIELDS =
-            "Extra irrelevant flags found in the command: ";
+            "Extra irrelevant options found in the command: ";
+    public static final String MESSAGE_UNEXPECTED_NON_EMPTY_FIELDS =
+            "The following options may not have any value: ";
+
     public static final String MESSAGE_INVALID_FIELD =
-            "The term '%s' is not a valid flag!";
+            "The term '%s' is not a valid option!";
 
     /**
      * Returns an error message indicating the duplicate flags.
@@ -42,10 +45,20 @@ public class Messages {
     public static String getErrorMessageForExtraneousFlags(Flag... extraneousFlags) {
         assert extraneousFlags.length > 0;
 
-        Set<String> duplicateFields =
+        Set<String> extraneousFields =
                 Stream.of(extraneousFlags).map(Flag::toString).collect(Collectors.toSet());
 
-        return MESSAGE_EXTRA_FIELDS + String.join(" ", duplicateFields);
+        return MESSAGE_EXTRA_FIELDS + String.join(" ", extraneousFields);
+    }
+
+    public static String getErrorMessageForNonEmptyValuedFlags(Flag... nonEmptyValuedFlags) {
+        assert nonEmptyValuedFlags.length > 0;
+
+        Set<String> nonEmptyValuedFields =
+                Stream.of(nonEmptyValuedFlags).map(Flag::toString).collect(Collectors.toSet());
+
+        return MESSAGE_UNEXPECTED_NON_EMPTY_FIELDS + String.join(" ", nonEmptyValuedFields);
+
     }
 
     /**

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -20,6 +20,8 @@ public class Messages {
             "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_EXTRA_FIELDS =
             "Extra irrelevant flags found in the command: ";
+    public static final String MESSAGE_INVALID_FIELD =
+            "The term '%s' is not a valid flag!";
 
     /**
      * Returns an error message indicating the duplicate flags.
@@ -43,6 +45,15 @@ public class Messages {
                 Stream.of(extraneousFlags).map(Flag::toString).collect(Collectors.toSet());
 
         return MESSAGE_EXTRA_FIELDS + String.join(" ", duplicateFields);
+    }
+
+    /**
+     * Returns an error message indicating the invalid flag.
+     */
+    public static String getErrorMessageForInvalidFlagString(String flagString) {
+        return String.format(
+                MESSAGE_INVALID_FIELD, flagString
+        );
     }
 
     /**

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -17,7 +17,9 @@ public class Messages {
     public static final String MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX = "The contact index provided is invalid";
     public static final String MESSAGE_CONTACTS_LISTED_OVERVIEW = "%1$d contacts listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
-                "Multiple values specified for the following single-valued field(s): ";
+            "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_EXTRA_FIELDS =
+            "Extra irrelevant flags found in the command: ";
 
     /**
      * Returns an error message indicating the duplicate flags.
@@ -29,6 +31,18 @@ public class Messages {
                 Stream.of(duplicateFlags).map(Flag::toString).collect(Collectors.toSet());
 
         return MESSAGE_DUPLICATE_FIELDS + String.join(" ", duplicateFields);
+    }
+
+    /**
+     * Returns an error message indicating the extraneous flags.
+     */
+    public static String getErrorMessageForExtraneousFlags(Flag... extraneousFlags) {
+        assert extraneousFlags.length > 0;
+
+        Set<String> duplicateFields =
+                Stream.of(extraneousFlags).map(Flag::toString).collect(Collectors.toSet());
+
+        return MESSAGE_EXTRA_FIELDS + String.join(" ", duplicateFields);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -16,7 +16,6 @@ import static seedu.address.logic.parser.CliSyntax.FLAG_URL;
 
 import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddOrganizationCommand;
@@ -53,17 +52,17 @@ public class AddCommandParser implements Parser<AddCommand> {
                 FLAG_ORGANIZATION_ID,
                 FLAG_ORGANIZATION, FLAG_RECRUITER);
 
-        if (!areFlagsPresent(argMultimap, FLAG_NAME, FLAG_PHONE, FLAG_EMAIL, FLAG_ADDRESS)
+        if (!argMultimap.hasAllOfFlags(FLAG_NAME, FLAG_PHONE, FLAG_EMAIL, FLAG_ADDRESS)
             || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
         argMultimap.verifyNoDuplicateFlagsFor(FLAG_NAME, FLAG_ID, FLAG_PHONE, FLAG_EMAIL, FLAG_URL, FLAG_ADDRESS);
 
-        if (areFlagsPresent(argMultimap, FLAG_ORGANIZATION)) {
+        if (argMultimap.hasFlag(FLAG_ORGANIZATION)) {
             Organization organization = parseAsOrganization(argMultimap);
             return new AddOrganizationCommand(organization);
-        } else if (areFlagsPresent(argMultimap, FLAG_RECRUITER)) {
+        } else if (argMultimap.hasFlag(FLAG_RECRUITER)) {
             Recruiter recruiter = parseAsRecruiter(argMultimap);
             return new AddCommand(recruiter);
         }
@@ -159,14 +158,6 @@ public class AddCommandParser implements Parser<AddCommand> {
         }
 
         return new Organization(name, id, phone, email, url, address, tagList, status, position);
-    }
-
-    /**
-     * Returns true if none of the flags contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean areFlagsPresent(ArgumentMultimap argumentMultimap, Flag... flags) {
-        return Stream.of(flags).allMatch(flag -> argumentMultimap.getValue(flag).isPresent());
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -85,7 +85,21 @@ public class ArgumentMultimap {
     }
 
     /**
+     * Returns whether the given {@code flag} has a non-empty value assigned to it.
+     * This returns true if the flag exists and is set to some non-empty string, and false otherwise.
+     */
+    public boolean hasNonEmptyValue(Flag flag) {
+        for (String value : getAllValues(flag)) {
+            if (!value.isEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Returns the last value of {@code flag}, if the flag exists.
+     * Note that an empty string or longer is guaranteed to be given if the flag exists.
      */
     public Optional<String> getValue(Flag flag) {
         List<String> values = getAllValues(flag);
@@ -138,6 +152,21 @@ public class ArgumentMultimap {
 
         if (extraneousFlags.length > 0) {
             throw new ParseException(Messages.getErrorMessageForExtraneousFlags(extraneousFlags));
+        }
+    }
+
+    /**
+     * Throws a {@code ParseException} if any of the flags given in {@code flags} have a non-empty value
+     * assigned to it.
+     */
+    public void verifyAllEmptyValuesAssignedFor(Flag... flags) throws ParseException {
+        Flag[] flagsWithUsefulValues = Stream.of(flags).distinct()
+                .filter(argMultimap::containsKey)
+                .filter(f -> argMultimap.get(f).stream().anyMatch(s -> !s.isEmpty()))
+                .toArray(Flag[]::new);
+
+        if (flagsWithUsefulValues.length > 0) {
+            throw new ParseException(Messages.getErrorMessageForNonEmptyValuedFlags(flagsWithUsefulValues));
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -28,21 +28,21 @@ public class ArgumentMultimap {
     /**
      * Associates the specified argument value with {@code flag} key in this map.
      * If the map previously contained a mapping for the key, the new value is appended to the list of existing values.
-     * Leading and trailing whitespaces are trimmed.
+     * Leading and trailing whitespaces are trimmed, and null values are treated as empty strings.
      *
      * @param flag     Flag key with which the specified argument value is to be associated.
      * @param argValue Argument value to be associated with the specified flag key.
      */
     public void put(Flag flag, String argValue) {
         List<String> argValues = getAllValues(flag);
-        argValues.add(argValue.trim());
+        argValues.add(argValue == null ? "" : argValue.trim());
         argMultimap.put(flag, argValues);
     }
 
     /**
      * Associates the specified value with the preamble of this map.
      * If the map previously contained a preamble, it will be replaced with this one.
-     * Leading and trailing whitespaces are trimmed.
+     * Leading and trailing whitespaces are trimmed, and null values are treated as empty strings.
      *
      * @param preamble Argument value to be associated with the preamble.
      */
@@ -51,20 +51,11 @@ public class ArgumentMultimap {
     }
 
     /**
-     * Returns the last value of {@code flag}, if the flag exists.
-     */
-    public Optional<String> getValue(Flag flag) {
-        List<String> values = getAllValues(flag);
-        return values.isEmpty() ? Optional.empty() : Optional.of(values.get(values.size() - 1));
-    }
-
-    /**
      * Returns whether there exists at least one occurrence of the given {@code flag} in this map.
      * Invoking {@code .hasFlag(flag)} is equivalent to the result obtained via {@code .getValue(flag).isPresent()}.
      */
     public boolean hasFlag(Flag flag) {
-        List<String> values = getAllValues(flag);
-        return !values.isEmpty() && values.get(values.size() - 1) != null;
+        return !getAllValues(flag).isEmpty();
     }
 
     /**
@@ -91,6 +82,14 @@ public class ArgumentMultimap {
             }
         }
         return false;
+    }
+
+    /**
+     * Returns the last value of {@code flag}, if the flag exists.
+     */
+    public Optional<String> getValue(Flag flag) {
+        List<String> values = getAllValues(flag);
+        return values.isEmpty() ? Optional.empty() : Optional.of(values.get(values.size() - 1));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -59,12 +59,38 @@ public class ArgumentMultimap {
     }
 
     /**
-     * Returns whether there exists at least one occurrence the given defined {@code flag} in this map.
-     * Invoking {@code .hasFlag(flag)} is equivalent to the result in {@code .getValue(flag).isPresent()}.
+     * Returns whether there exists at least one occurrence of the given {@code flag} in this map.
+     * Invoking {@code .hasFlag(flag)} is equivalent to the result obtained via {@code .getValue(flag).isPresent()}.
      */
     public boolean hasFlag(Flag flag) {
         List<String> values = getAllValues(flag);
         return !values.isEmpty() && values.get(values.size() - 1) != null;
+    }
+
+    /**
+     * Returns whether there exists at least one occurrence of all of these {@code flags} in this map.
+     * Equivalent to the AND of booleans obtained via {@link #hasFlag} for all provided flags.
+     */
+    public boolean hasAllOfFlags(Flag... flags) {
+        for (Flag flag : flags) {
+            if (!this.hasFlag(flag)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns whether there exists at least one occurrence of at least one of these {@code flags} in this map.
+     * Equivalent to the OR of booleans obtained via {@link #hasFlag} for all provided flags.
+     */
+    public boolean hasAnyOfFlags(Flag... flags) {
+        for (Flag flag : flags) {
+            if (this.hasFlag(flag)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -1,13 +1,11 @@
 package seedu.address.logic.parser;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
- * Tokenizes arguments string of the form: {@code preamble <flag>value <flag>value ...}<br>
- *     e.g. {@code some preamble text t/ 11.00 t/12.00 k/ m/ July}  where flag are {@code t/ k/ m/}.<br>
+ * Tokenizes arguments string of the form: {@code preamble <flag> value <flag> value ...}<br>
+ *     e.g. {@code some preamble text t/ 11.00 t/ 12.00 k/ m/ July}  where flag are {@code t/ k/ m/}.<br>
  * 1. An argument's value can be an empty string e.g. the value of {@code k/} in the above example.<br>
  * 2. Leading and trailing whitespaces of an argument value will be discarded.<br>
  * 3. An argument may be repeated and all its values will be accumulated e.g. the value of {@code t/}
@@ -19,60 +17,45 @@ public class ArgumentTokenizer {
      * Tokenizes an arguments string and returns an {@code ArgumentMultimap} object that maps flag to their
      * respective argument values. Only the given flag will be recognized in the arguments string.
      *
-     * @param argsString Arguments string of the form: {@code preamble <flag>value <flag>value ...}
-     * @param flags   Flags to tokenize the arguments string with
+     * @param argsString Arguments string of the form: {@code preamble <flag> value <flag> value ...}
+     * @param flags      Flags to prioritize tokenizing the arguments string with
      * @return           ArgumentMultimap object that maps flag to their arguments
      */
     public static ArgumentMultimap tokenize(String argsString, Flag... flags) {
-        List<FlagPosition> positions = findAllFlagPositions(argsString, flags);
-        return extractArguments(argsString, positions);
+        String[] words = splitByWords(argsString);
+        return extractArguments(words, flags);
     }
 
+
     /**
-     * Finds all zero-based flag positions in the given arguments string.
+     * Splits an arguments string into individual words, separated by space.
      *
-     * @param argsString Arguments string of the form: {@code preamble <flag>value <flag>value ...}
-     * @param flags   Flags to find in the arguments string
-     * @return           List of zero-based flag positions in the given arguments string
+     * @param argsString Arguments string of the form: {@code preamble <flag> value <flag> value ...}
+     * @return The terms formed after splitting the arguments string by the space character.
      */
-    private static List<FlagPosition> findAllFlagPositions(String argsString, Flag... flags) {
-        return Arrays.stream(flags)
-                .flatMap(flag -> findFlagPositions(argsString, flag).stream())
-                .collect(Collectors.toList());
+    private static String[] splitByWords(String argsString) {
+        return argsString.split(" ");
     }
 
     /**
-     * {@see findAllFlagPositions}
+     * Locate all the locations in the words list that represent flags.
+     *
+     * @param wordsArray An array of words.
+     * @param targetedFlags An array of flags should be checked explicitly.
+     * @return The list of indices where a flag can be found.
      */
-    private static List<FlagPosition> findFlagPositions(String argsString, Flag flag) {
-        List<FlagPosition> positions = new ArrayList<>();
+    private static List<Integer> findFlagIndices(String[] wordsArray, Flag[] targetedFlags) {
 
-        int flagPosition = findFlagPosition(argsString, flag.getFlagString(), 0);
-        while (flagPosition != -1) {
-            FlagPosition extendedFlag = new FlagPosition(flag, flagPosition);
-            positions.add(extendedFlag);
-            flagPosition = findFlagPosition(argsString, flag.getFlagString(), flagPosition);
+        List<Integer> flagIndices = new ArrayList<>();
+        for (int i = 0; i < wordsArray.length; i++) {
+            String word = wordsArray[i];
+
+            if (Flag.isFlagSyntax(word) || Flag.findMatch(word, targetedFlags).isPresent()) {
+                flagIndices.add(i);
+            }
         }
 
-        return positions;
-    }
-
-    /**
-     * Returns the index of the first occurrence of {@code flag} in
-     * {@code argsString} starting from index {@code fromIndex}. An occurrence
-     * is valid if there is a whitespace before {@code flag}. Returns -1 if no
-     * such occurrence can be found.
-     *
-     * E.g if {@code argsString} = "e/hip/900", {@code flag} = "p/" and
-     * {@code fromIndex} = 0, this method returns -1 as there are no valid
-     * occurrences of "p/" with whitespace before it. However, if
-     * {@code argsString} = "e/hi p/900", {@code flag} = "p/" and
-     * {@code fromIndex} = 0, this method returns 5.
-     */
-    private static int findFlagPosition(String argsString, String flag, int fromIndex) {
-        int flagIndex = argsString.indexOf(" " + flag, fromIndex);
-        return flagIndex == -1 ? -1
-                : flagIndex + 1; // +1 as offset for whitespace
+        return flagIndices;
     }
 
     /**
@@ -80,70 +63,52 @@ public class ArgumentTokenizer {
      * extracted flag to their respective arguments. Flags are extracted based on their zero-based positions in
      * {@code argsString}.
      *
-     * @param argsString      Arguments string of the form: {@code preamble <flag>value <flag>value ...}
-     * @param flagPositions Zero-based positions of all flag in {@code argsString}
-     * @return                ArgumentMultimap object that maps flag to their arguments
+     * @param words           An array of words derived from the arguments string.
+     * @param targetedFlags   An array of flags should be checked explicitly.
+     * @return                ArgumentMultimap object that maps flags to their arguments.
      */
-    private static ArgumentMultimap extractArguments(String argsString, List<FlagPosition> flagPositions) {
+    private static ArgumentMultimap extractArguments(String[] words, Flag[] targetedFlags) {
 
-        // Sort by start position
-        flagPositions.sort((flag1, flag2) -> flag1.getStartPosition() - flag2.getStartPosition());
+        List<String> wordsList = List.of(words);
 
-        // Insert a FlagPosition to represent the preamble
-        FlagPosition preambleMarker = new FlagPosition(new Flag("", null, null), 0);
-        flagPositions.add(0, preambleMarker);
+        // Define a "segment" to be the end of a value or preamble.
+        // We prepare a list that marks the upper bound for a segment via an *exclusive* index.
+        // In other words, if the list has [3, 5], it means there are two segments with ranges [0,3) and [3,5).
+        List<Integer> endOfBoundsIndices = new ArrayList<>();
 
-        // Add a dummy FlagPosition to represent the end of the string
-        FlagPosition endPositionMarker = new FlagPosition(new Flag("", null, null), argsString.length());
-        flagPositions.add(endPositionMarker);
+        endOfBoundsIndices.addAll(findFlagIndices(words, targetedFlags));
+        endOfBoundsIndices.add(words.length);
 
-        // Map flag to their argument values (if any)
+        // Search through the ranges and map flag to their argument values (if any)
         ArgumentMultimap argMultimap = new ArgumentMultimap();
-        for (int i = 0; i < flagPositions.size() - 1; i++) {
-            // Extract and store flag and their arguments
-            Flag argFlag = flagPositions.get(i).getFlag();
-            String argValue = extractArgumentValue(argsString, flagPositions.get(i), flagPositions.get(i + 1));
-            argMultimap.put(argFlag, argValue);
+        for (int i = 0; i < endOfBoundsIndices.size(); i++) {
+
+            // Note that the bounds are [start, end), i.e., start <= x < end.
+            int start = i == 0 ? 0 : endOfBoundsIndices.get(i - 1);
+            int end = endOfBoundsIndices.get(i);
+
+            if (start >= end) {
+                continue;
+            }
+
+            // Case 1: Preamble (if we reach here in the first loop iteration).
+            if (i == 0) {
+                String preamble = String.join(" ", wordsList.subList(start, end)).trim();
+                argMultimap.putPreamble(preamble);
+                continue;
+            }
+
+            // Case 2: Flag + Possible Argument Value (if we reach here in 2nd+ loop iterations).
+            String flagString = words[start];
+            String valueString = String.join(" ", wordsList.subList(start + 1, end)).trim();
+
+            Flag flag = Flag.findMatch(words[start], targetedFlags) // Try to get it from the explicit flags first...
+                    .orElse(Flag.parse(flagString)); // ...or otherwise parse with the default rules.
+
+            argMultimap.put(flag, valueString);
         }
 
         return argMultimap;
-    }
-
-    /**
-     * Returns the trimmed value of the argument in the arguments string specified by {@code currentFlagPosition}.
-     * The end position of the value is determined by {@code nextFlagPosition}.
-     */
-    private static String extractArgumentValue(String argsString,
-                                        FlagPosition currentFlagPosition,
-                                        FlagPosition nextFlagPosition
-    ) {
-        Flag flag = currentFlagPosition.getFlag();
-
-        int valueStartPos = currentFlagPosition.getStartPosition() + flag.getFlagString().length();
-        String value = argsString.substring(valueStartPos, nextFlagPosition.getStartPosition());
-
-        return value.trim();
-    }
-
-    /**
-     * Represents a flag's position in an arguments string.
-     */
-    private static class FlagPosition {
-        private int startPosition;
-        private final Flag flag;
-
-        FlagPosition(Flag flag, int startPosition) {
-            this.flag = flag;
-            this.startPosition = startPosition;
-        }
-
-        int getStartPosition() {
-            return startPosition;
-        }
-
-        Flag getFlag() {
-            return flag;
-        }
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Tokenizes arguments string of the form: {@code preamble <flag> value <flag> value ...}<br>

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Tokenizes arguments string of the form: {@code preamble <flag> value <flag> value ...}<br>
@@ -102,8 +103,9 @@ public class ArgumentTokenizer {
             String flagString = words[start];
             String valueString = String.join(" ", wordsList.subList(start + 1, end)).trim();
 
-            Flag flag = Flag.findMatch(words[start], targetedFlags) // Try to get it from the explicit flags first...
-                    .orElse(Flag.parse(flagString)); // ...or otherwise parse with the default rules.
+            Flag flag = Flag.findMatch(flagString, targetedFlags)
+                    .or(() -> Flag.parseOptional(flagString))
+                    .orElseThrow(); // We should never get here since the flags are validated in findFlagIndices.
 
             argMultimap.put(flag, valueString);
         }

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -71,21 +71,21 @@ public class ArgumentTokenizer {
 
         List<String> wordsList = List.of(words);
 
-        // Define a "segment" to be the end of a value or preamble.
-        // We prepare a list that marks the upper bound for a segment via an *exclusive* index.
-        // In other words, if the list has [3, 5], it means there are two segments with ranges [0,3) and [3,5).
-        List<Integer> endOfBoundsIndices = new ArrayList<>();
+        // Define an "end of range" to be the end of a value or preamble.
+        // We prepare a list that marks the end of ranges via *exclusive* indices (i.e., end index + 1).
+        // In other words, if the list has [3, 5], it means there are two ranges [0,3) and [3,5).
+        List<Integer> endOfRangeIndices = new ArrayList<>();
 
-        endOfBoundsIndices.addAll(findFlagIndices(words, targetedFlags));
-        endOfBoundsIndices.add(words.length);
+        endOfRangeIndices.addAll(findFlagIndices(words, targetedFlags));
+        endOfRangeIndices.add(words.length);
 
         // Search through the ranges and map flag to their argument values (if any)
         ArgumentMultimap argMultimap = new ArgumentMultimap();
-        for (int i = 0; i < endOfBoundsIndices.size(); i++) {
+        for (int i = 0; i < endOfRangeIndices.size(); i++) {
 
             // Note that the bounds are [start, end), i.e., start <= x < end.
-            int start = i == 0 ? 0 : endOfBoundsIndices.get(i - 1);
-            int end = endOfBoundsIndices.get(i);
+            int start = i == 0 ? 0 : endOfRangeIndices.get(i - 1);
+            int end = endOfRangeIndices.get(i);
 
             if (start >= end) {
                 continue;

--- a/src/main/java/seedu/address/logic/parser/Flag.java
+++ b/src/main/java/seedu/address/logic/parser/Flag.java
@@ -3,6 +3,9 @@ package seedu.address.logic.parser;
 import java.util.Objects;
 import java.util.Optional;
 
+import seedu.address.logic.Messages;
+import seedu.address.logic.parser.exceptions.ParseException;
+
 /**
  * A flag is an argument in and of itself. It functions as a option specifier, or as a marker for the beginning of a
  * command argument.
@@ -45,12 +48,14 @@ public class Flag {
      * Parses the given string using the default prefix and postfix format into a {@link Flag}.
      *
      * @param string The string to check for flag-like formats.
-     * @return true if the string resembles a flag, false otherwise.
-     * @throws IllegalArgumentException if the flag is invalid.
+     * @return The corresponding {@link Flag} instance.
+     * @throws ParseException if the flag is invalid.
      */
-    public static Flag parse(String string) {
+    public static Flag parse(String string) throws ParseException {
         if (!isFlagSyntax(string)) {
-            throw new IllegalArgumentException("Attempted to parse non-flag string as flag");
+            throw new ParseException(
+                    Messages.getErrorMessageForInvalidFlagString(string)
+            );
         }
 
         return new Flag(string.substring(
@@ -58,6 +63,22 @@ public class Flag {
                 string.length() - DEFAULT_POSTFIX.length()
         ));
     }
+
+    /**
+     * Parses the given string using the default prefix and postfix format into an optional {@link Flag},
+     * which will return an empty optional if it's invalid.
+     *
+     * @param string The string to check for flag-like formats.
+     * @return An optional containing the flag if it is a valid flag format.
+     */
+    public static Optional<Flag> parseOptional(String string) {
+        try {
+            return Optional.of(parse(string));
+        } catch (ParseException e) {
+            return Optional.empty();
+        }
+    }
+
 
     /**
      * Finds a {@link Flag} from the given {@code flags} that matches the given string representation.

--- a/src/main/java/seedu/address/logic/parser/Flag.java
+++ b/src/main/java/seedu/address/logic/parser/Flag.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * A flag is an argument in and of itself. It functions as a option specifier, or as a marker for the beginning of a
@@ -40,6 +41,41 @@ public class Flag {
         this.postfix = postfix == null ? "" : postfix.trim();
     }
 
+    /**
+     * Parses the given string using the default prefix and postfix format into a {@link Flag}.
+     *
+     * @param string The string to check for flag-like formats.
+     * @return true if the string resembles a flag, false otherwise.
+     * @throws IllegalArgumentException if the flag is invalid.
+     */
+    public static Flag parse(String string) {
+        if (!isFlagSyntax(string)) {
+            throw new IllegalArgumentException("Attempted to parse non-flag string as flag");
+        }
+
+        return new Flag(string.substring(
+                DEFAULT_PREFIX.length(),
+                string.length() - DEFAULT_POSTFIX.length()
+        ));
+    }
+
+    /**
+     * Finds a {@link Flag} from the given {@code flags} that matches the given string representation.
+     *
+     * @param string The string to check for a corresponding matching flag or flag-like formats.
+     * @param flags The array of flags to check from.
+     * @return An optional instance with the result if there is a successful match.
+     * @throws IllegalArgumentException if the flag is invalid.
+     */
+    public static Optional<Flag> findMatch(String string, Flag[] flags) {
+        for (Flag flag : flags) {
+            if (string != null && string.equals(flag.getFlagString())) {
+                return Optional.of(flag);
+            }
+        }
+        return Optional.empty();
+    }
+
     public String getName() {
         return name;
     }
@@ -59,6 +95,21 @@ public class Flag {
      */
     public String getFlagString() {
         return this.toString();
+    }
+
+    /**
+     * Checks whether the given string representation resembles a flag.
+     * If this is true, then it resembles the default prefix-name-postfix format specified in {@link Flag},
+     * and is a plausible output from {@link Flag#getFlagString()}.
+     *
+     * @param string The string to check for flag-like formats.
+     * @return true if the string resembles a flag, false otherwise.
+     */
+    public static boolean isFlagSyntax(String string) {
+        if (string == null) {
+            return false;
+        }
+        return string.startsWith(DEFAULT_PREFIX) && string.endsWith(DEFAULT_POSTFIX);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -6,8 +6,6 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CONTACTS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ONLY_ORGANIZATIONS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ONLY_RECRUITERS;
 
-import java.util.stream.Stream;
-
 import seedu.address.logic.commands.ListCommand;
 
 /**
@@ -22,25 +20,17 @@ public class ListCommandParser implements Parser<ListCommand> {
     public ListCommand parse(String args) {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, FLAG_ORGANIZATION, FLAG_RECRUITER);
 
-        if (areFlagsPresent(argMultimap, FLAG_ORGANIZATION, FLAG_RECRUITER)) {
+        if (argMultimap.hasAllOfFlags(FLAG_ORGANIZATION, FLAG_RECRUITER)) {
             return new ListCommand(PREDICATE_SHOW_ALL_CONTACTS);
         }
 
-        if (areFlagsPresent(argMultimap, FLAG_ORGANIZATION)) {
+        if (argMultimap.hasFlag(FLAG_ORGANIZATION)) {
             return new ListCommand(PREDICATE_SHOW_ONLY_ORGANIZATIONS);
-        } else if (areFlagsPresent(argMultimap, FLAG_RECRUITER)) {
+        } else if (argMultimap.hasFlag(FLAG_RECRUITER)) {
             return new ListCommand(PREDICATE_SHOW_ONLY_RECRUITERS);
         }
 
         return new ListCommand(PREDICATE_SHOW_ALL_CONTACTS);
-    }
-
-    /**
-     * Returns true if none of the flags contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean areFlagsPresent(ArgumentMultimap argumentMultimap, Flag... flags) {
-        return Stream.of(flags).allMatch(flag -> argumentMultimap.getValue(flag).isPresent());
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -44,29 +44,29 @@ public class CommandTestUtil {
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
-    public static final String NAME_DESC_AMY = " " + FLAG_NAME + VALID_NAME_AMY;
-    public static final String NAME_DESC_BOB = " " + FLAG_NAME + VALID_NAME_BOB;
-    public static final String ID_DESC_AMY = " " + FLAG_ID + VALID_ID_AMY;
-    public static final String ID_DESC_BOB = " " + FLAG_ID + VALID_ID_BOB;
-    public static final String PHONE_DESC_AMY = " " + FLAG_PHONE + VALID_PHONE_AMY;
-    public static final String PHONE_DESC_BOB = " " + FLAG_PHONE + VALID_PHONE_BOB;
-    public static final String EMAIL_DESC_AMY = " " + FLAG_EMAIL + VALID_EMAIL_AMY;
-    public static final String EMAIL_DESC_BOB = " " + FLAG_EMAIL + VALID_EMAIL_BOB;
-    public static final String ADDRESS_DESC_AMY = " " + FLAG_ADDRESS + VALID_ADDRESS_AMY;
-    public static final String ADDRESS_DESC_BOB = " " + FLAG_ADDRESS + VALID_ADDRESS_BOB;
+    public static final String NAME_DESC_AMY = " " + FLAG_NAME + " " + VALID_NAME_AMY;
+    public static final String NAME_DESC_BOB = " " + FLAG_NAME + " " + VALID_NAME_BOB;
+    public static final String ID_DESC_AMY = " " + FLAG_ID + " " + VALID_ID_AMY;
+    public static final String ID_DESC_BOB = " " + FLAG_ID + " " + VALID_ID_BOB;
+    public static final String PHONE_DESC_AMY = " " + FLAG_PHONE + " " + VALID_PHONE_AMY;
+    public static final String PHONE_DESC_BOB = " " + FLAG_PHONE + " " + VALID_PHONE_BOB;
+    public static final String EMAIL_DESC_AMY = " " + FLAG_EMAIL + " " + VALID_EMAIL_AMY;
+    public static final String EMAIL_DESC_BOB = " " + FLAG_EMAIL + " " + VALID_EMAIL_BOB;
+    public static final String ADDRESS_DESC_AMY = " " + FLAG_ADDRESS + " " + VALID_ADDRESS_AMY;
+    public static final String ADDRESS_DESC_BOB = " " + FLAG_ADDRESS + " " + VALID_ADDRESS_BOB;
 
-    public static final String URL_DESC_AMY = " " + FLAG_URL + VALID_URL_AMY;
-    public static final String URL_DESC_BOB = " " + FLAG_URL + VALID_URL_BOB;
-    public static final String TAG_DESC_FRIEND = " " + FLAG_TAG + VALID_TAG_FRIEND;
-    public static final String TAG_DESC_HUSBAND = " " + FLAG_TAG + VALID_TAG_HUSBAND;
+    public static final String URL_DESC_AMY = " " + FLAG_URL + " " + VALID_URL_AMY;
+    public static final String URL_DESC_BOB = " " + FLAG_URL + " " + VALID_URL_BOB;
+    public static final String TAG_DESC_FRIEND = " " + FLAG_TAG + " " + VALID_TAG_FRIEND;
+    public static final String TAG_DESC_HUSBAND = " " + FLAG_TAG + " " + VALID_TAG_HUSBAND;
 
-    public static final String INVALID_NAME_DESC = " " + FLAG_NAME + "James&"; // '&' not allowed in names
-    public static final String INVALID_ID_DESC = " " + FLAG_ID + "e91724&_18273"; // '&' not allowed in ids
-    public static final String INVALID_PHONE_DESC = " " + FLAG_PHONE + "911a"; // 'a' not allowed in phones
-    public static final String INVALID_EMAIL_DESC = " " + FLAG_EMAIL + "bob!yahoo"; // missing '@' symbol
+    public static final String INVALID_NAME_DESC = " " + FLAG_NAME + " " + "James&"; // '&' not allowed in names
+    public static final String INVALID_ID_DESC = " " + FLAG_ID + " " + "e91724&_18273"; // '&' not allowed in ids
+    public static final String INVALID_PHONE_DESC = " " + FLAG_PHONE + " " + "911a"; // 'a' not allowed in phones
+    public static final String INVALID_EMAIL_DESC = " " + FLAG_EMAIL + " " + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + FLAG_ADDRESS; // empty string not allowed for addresses
-    public static final String INVALID_URL_DESC = " " + FLAG_URL + "asdfjkl";
-    public static final String INVALID_TAG_DESC = " " + FLAG_TAG + "hubby*"; // '*' not allowed in tags
+    public static final String INVALID_URL_DESC = " " + FLAG_URL + " " + "asdfjkl";
+    public static final String INVALID_TAG_DESC = " " + FLAG_TAG + " " + "hubby*"; // '*' not allowed in tags
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/address/logic/parser/ArgumentMultimapTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentMultimapTest.java
@@ -1,0 +1,412 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class ArgumentMultimapTest {
+
+    private static final Flag FLAG_A = new Flag("aaa");
+    private static final Flag FLAG_B = new Flag("bbb");
+    private static final Flag FLAG_C = new Flag("ccc");
+    private static final Flag FLAG_D = new Flag("ddd");
+
+
+
+    @Test
+    public void hasFlag_existingFlagsSet_trueReturned() {
+        // Will return true if value is set
+        ArgumentMultimap multimap = new ArgumentMultimap();
+        multimap.put(FLAG_A, "1 value");
+        assertTrue(multimap.hasFlag(FLAG_A));
+
+        // Adding more inputs don't impact the result
+        multimap.put(FLAG_A, "2 value");
+        multimap.put(FLAG_A, "3 value");
+        assertTrue(multimap.hasFlag(FLAG_A));
+
+        // Some test cases with more flags
+        multimap = new ArgumentMultimap();
+        multimap.put(FLAG_A, "blah");
+        multimap.put(FLAG_B, " zzzzz ");
+        multimap.put(FLAG_B, " test");
+        multimap.put(FLAG_C, "contact ");
+
+        assertTrue(multimap.hasFlag(FLAG_A));
+        assertTrue(multimap.hasFlag(FLAG_B));
+        assertTrue(multimap.hasFlag(FLAG_C));
+    }
+    @Test
+    public void hasFlag_missingFlag_falseReturned() {
+        // Empty map trivially doesn't have the value
+        ArgumentMultimap multimap = new ArgumentMultimap();
+        assertFalse(multimap.hasFlag(FLAG_A));
+
+        // Nonempty map but target value not present
+        multimap = new ArgumentMultimap();
+        multimap.put(FLAG_B, "bbbbb");
+        assertFalse(multimap.hasFlag(FLAG_A));
+
+        // Subsequent additions without adding target value will not change result
+        multimap.put(FLAG_C, "ccccc");
+        assertFalse(multimap.hasFlag(FLAG_A));
+    }
+
+    @Test
+    public void hasAllOfFlags_completeMatch_trueReturned() {
+        // Populated map
+        ArgumentMultimap multimap = new ArgumentMultimap();
+        multimap.put(FLAG_A, "aaa");
+        multimap.put(FLAG_B, "bbb1");
+        multimap.put(FLAG_B, "bbb2");
+        multimap.put(FLAG_C, "ccc");
+
+        assertTrue(multimap.hasAllOfFlags()); // Trivially, any map will contain every element in an empty list [].
+
+        assertTrue(multimap.hasAllOfFlags(FLAG_A));
+        assertTrue(multimap.hasAllOfFlags(FLAG_B));
+        assertTrue(multimap.hasAllOfFlags(FLAG_C));
+
+        assertTrue(multimap.hasAllOfFlags(FLAG_A, FLAG_B));
+        assertTrue(multimap.hasAllOfFlags(FLAG_B, FLAG_C));
+        assertTrue(multimap.hasAllOfFlags(FLAG_C, FLAG_A));
+
+        assertTrue(multimap.hasAllOfFlags(FLAG_A, FLAG_B, FLAG_C));
+
+        // Empty map
+        multimap = new ArgumentMultimap();
+        assertTrue(multimap.hasAllOfFlags()); // Similar to above, it has all elements in [].
+    }
+
+    @Test
+    public void hasAllOfFlags_partialOrNoMatch_falseReturned() {
+        // Populated map
+        ArgumentMultimap multimap = new ArgumentMultimap();
+        multimap.put(FLAG_A, "A");
+        multimap.put(FLAG_B, "B");
+        multimap.put(FLAG_B, "B");
+
+        assertFalse(multimap.hasAllOfFlags(FLAG_C));
+
+        assertFalse(multimap.hasAllOfFlags(FLAG_A, FLAG_C));
+        assertFalse(multimap.hasAllOfFlags(FLAG_B, FLAG_C));
+
+        assertFalse(multimap.hasAllOfFlags(FLAG_A, FLAG_B, FLAG_C));
+
+        // Empty map
+        multimap = new ArgumentMultimap();
+        assertFalse(multimap.hasAllOfFlags(FLAG_A));
+        assertFalse(multimap.hasAllOfFlags(FLAG_A, FLAG_B));
+        assertFalse(multimap.hasAllOfFlags(FLAG_A, FLAG_B, FLAG_C));
+    }
+
+    @Test
+    public void hasAnyOfFlags_partialOrCompleteMatch_trueReturned() {
+        // Populated map
+        ArgumentMultimap multimap = new ArgumentMultimap();
+        multimap.put(FLAG_A, "123");
+        multimap.put(FLAG_B, "456");
+        multimap.put(FLAG_B, "789");
+
+        assertTrue(multimap.hasAnyOfFlags(FLAG_A));
+        assertTrue(multimap.hasAnyOfFlags(FLAG_B));
+
+        assertTrue(multimap.hasAnyOfFlags(FLAG_A, FLAG_B));
+        assertTrue(multimap.hasAnyOfFlags(FLAG_A, FLAG_C));
+        assertTrue(multimap.hasAnyOfFlags(FLAG_B, FLAG_C));
+
+        assertTrue(multimap.hasAnyOfFlags(FLAG_A, FLAG_B, FLAG_C));
+
+        // Empty map
+        // - An empty map will never have a partial or complete match.
+    }
+
+    @Test
+    public void hasAnyOfFlags_noMatch_falseReturned() {
+        // Populated map
+        ArgumentMultimap multimap = new ArgumentMultimap();
+        multimap.put(FLAG_A, "000");
+
+        assertFalse(multimap.hasAnyOfFlags()); // Trivially, any map will not contain any elements from empty list [].
+        assertFalse(multimap.hasAnyOfFlags(FLAG_C));
+        assertFalse(multimap.hasAnyOfFlags(FLAG_B, FLAG_C));
+
+        // Empty map
+        multimap = new ArgumentMultimap();
+        assertFalse(multimap.hasAnyOfFlags()); // Similar to above, it will not have any elements in [].
+        assertFalse(multimap.hasAnyOfFlags(FLAG_A));
+        assertFalse(multimap.hasAnyOfFlags(FLAG_B));
+        assertFalse(multimap.hasAnyOfFlags(FLAG_A, FLAG_C));
+        assertFalse(multimap.hasAnyOfFlags(FLAG_C, FLAG_B, FLAG_A));
+    }
+
+    @Test
+    public void hasNonEmptyValue_nonEmpty_returnsTrue() {
+        ArgumentMultimap multimap = new ArgumentMultimap();
+        multimap.put(FLAG_A, "AAA");
+        multimap.put(FLAG_B, "");
+        multimap.put(FLAG_C, "CC1");
+        multimap.put(FLAG_C, "CC2");
+        multimap.put(FLAG_C, null);
+
+        assertTrue(multimap.hasNonEmptyValue(FLAG_A));
+        assertTrue(multimap.hasNonEmptyValue(FLAG_C));
+    }
+    @Test
+    public void hasNonEmptyValue_noFlagOrEmpty_returnsFalse() {
+        ArgumentMultimap multimap = new ArgumentMultimap();
+        multimap.put(FLAG_A, "AAA");
+        multimap.put(FLAG_B, "");
+
+        assertFalse(multimap.hasNonEmptyValue(FLAG_B));
+        assertFalse(multimap.hasNonEmptyValue(FLAG_C));
+
+        multimap = new ArgumentMultimap();
+        multimap.put(FLAG_A, null);
+        multimap.put(FLAG_A, "");
+
+        assertFalse(multimap.hasNonEmptyValue(FLAG_A));
+        assertFalse(multimap.hasNonEmptyValue(FLAG_D));
+    }
+
+
+    @Test
+    public void getValue_notPresent_emptyOptionalReturned() {
+        // Empty map trivially doesn't have the value
+        ArgumentMultimap multimap = new ArgumentMultimap();
+        assertTrue(multimap.getValue(FLAG_A).isEmpty());
+
+        // Nonempty map but target value not present
+        multimap = new ArgumentMultimap();
+        multimap.put(FLAG_B, "some data");
+        assertTrue(multimap.getValue(FLAG_A).isEmpty());
+
+        // Subsequent additions without adding target value will not change result
+        multimap.put(FLAG_C, "some more data");
+        assertTrue(multimap.getValue(FLAG_A).isEmpty());
+    }
+
+    @Test
+    public void getValue_existingValuesSet_lastValueReturned() {
+        // Will return a value if that is set
+        ArgumentMultimap multimap = new ArgumentMultimap();
+        multimap.put(FLAG_A, "a value");
+        assertTrue(multimap.getValue(FLAG_A).isPresent());
+        assertEquals("a value", multimap.getValue(FLAG_A).get());
+
+        // More than one inputs cause it to return the last one.
+        multimap.put(FLAG_A, "2nd value");
+        multimap.put(FLAG_A, "3rd value");
+        assertEquals("3rd value", multimap.getValue(FLAG_A).get());
+
+        // Some test cases with more flags and whitespace checks
+        multimap = new ArgumentMultimap();
+        multimap.put(FLAG_A, "\t testing A  ");
+        multimap.put(FLAG_B, "testing B 123 \n");
+        multimap.put(FLAG_B, "testing B 456\r\n  ");
+        multimap.put(FLAG_C, " CC  ");
+
+        assertTrue(multimap.getValue(FLAG_A).isPresent());
+        assertTrue(multimap.getValue(FLAG_B).isPresent());
+        assertTrue(multimap.getValue(FLAG_C).isPresent());
+
+        assertEquals("testing A", multimap.getValue(FLAG_A).get());
+        assertEquals("testing B 456", multimap.getValue(FLAG_B).get());
+        assertEquals("CC", multimap.getValue(FLAG_C).get());
+
+        multimap = new ArgumentMultimap();
+        multimap.put(FLAG_A, "A1 value");
+        multimap.put(FLAG_B, "B1 value");
+        multimap.put(FLAG_A, " A2 value");
+        multimap.put(FLAG_B, "B2 value ");
+        multimap.put(FLAG_B, "  "); // Empty value.
+        assertTrue(multimap.getValue(FLAG_A).isPresent());
+        assertTrue(multimap.getValue(FLAG_B).isPresent());
+        assertEquals("A2 value", multimap.getValue(FLAG_A).get());
+        assertEquals("", multimap.getValue(FLAG_B).get());
+
+        multimap.put(FLAG_A, null); // Empty value.
+        assertEquals("", multimap.getValue(FLAG_A).get());
+    }
+
+    @Test
+    public void getAllValues_existingValuesSet_allValuesReturned() {
+        // Will return a value if that is set
+        ArgumentMultimap multimap = new ArgumentMultimap();
+        multimap.put(FLAG_A, "a value");
+        assertTrue(multimap.getValue(FLAG_A).isPresent());
+        assertEquals(List.of("a value"), multimap.getAllValues(FLAG_A));
+
+        // More than one inputs cause it to return the last one.
+        multimap.put(FLAG_A, "2nd value");
+        multimap.put(FLAG_A, "3rd value");
+        assertEquals(List.of("a value", "2nd value", "3rd value"), multimap.getAllValues(FLAG_A));
+
+        // Some test cases with more flags and whitespace checks
+        multimap = new ArgumentMultimap();
+        multimap.put(FLAG_A, "\t testing A  ");
+        multimap.put(FLAG_B, "testing B 123 \n");
+        multimap.put(FLAG_B, "testing B 456\r\n  ");
+        multimap.put(FLAG_C, " CC  ");
+
+        assertEquals(List.of("testing A"), multimap.getAllValues(FLAG_A));
+        assertEquals(List.of("testing B 123", "testing B 456"), multimap.getAllValues(FLAG_B));
+        assertEquals(List.of("CC"), multimap.getAllValues(FLAG_C));
+
+        multimap = new ArgumentMultimap();
+        multimap.put(FLAG_A, "A1 value");
+        multimap.put(FLAG_B, "B1 value");
+        multimap.put(FLAG_A, " A2 value");
+        multimap.put(FLAG_B, "B2 value ");
+        multimap.put(FLAG_B, "  "); // Empty value.
+        assertTrue(multimap.getValue(FLAG_A).isPresent());
+        assertTrue(multimap.getValue(FLAG_B).isPresent());
+        assertEquals(List.of("A1 value", "A2 value"), multimap.getAllValues(FLAG_A));
+        assertEquals(List.of("B1 value", "B2 value", ""), multimap.getAllValues(FLAG_B));
+    }
+
+    @Test
+    public void getPreamble_noPreambleSet_returnsEmptyString() {
+        // Empty map has no preamble.
+        ArgumentMultimap multimap = new ArgumentMultimap();
+
+        assertNotNull(multimap.getPreamble());
+        assertTrue(multimap.getPreamble().isEmpty());
+        assertEquals("", multimap.getPreamble());
+
+        // Setting a preamble, then removing it, will remove the preamble.
+        multimap.putPreamble("testing");
+        multimap.putPreamble(null);
+
+        assertNotNull(multimap.getPreamble());
+        assertTrue(multimap.getPreamble().isEmpty());
+        assertEquals("", multimap.getPreamble());
+
+        // Similarly for setting to an empty string. Whitespace is trimmed.
+        multimap.putPreamble("  ");
+
+        assertNotNull(multimap.getPreamble());
+        assertTrue(multimap.getPreamble().isEmpty());
+        assertEquals("", multimap.getPreamble());
+    }
+    @Test
+    public void getPreamble_preambleSet_returnsPreamble() {
+        // Setting a preamble will give you that one.
+        ArgumentMultimap multimap = new ArgumentMultimap();
+        multimap.putPreamble("preamble val");
+        assertEquals("preamble val", multimap.getPreamble());
+
+        // Setting a new preamble will replace the old one.
+        multimap.putPreamble("preamble val 2.0");
+        assertEquals("preamble val 2.0", multimap.getPreamble());
+
+        // Removing the reamble, then setting it again, will have the new one.
+        multimap.putPreamble(null);
+        multimap.putPreamble("who's this");
+        assertEquals("who's this", multimap.getPreamble());
+    }
+
+
+    @Test
+    public void verifyNoDuplicateFlagsFor_noDuplicates_exceptionNotThrown() {
+        ArgumentMultimap multimap = new ArgumentMultimap();
+        multimap.put(FLAG_A, "a");
+        multimap.put(FLAG_C, "c1");
+        multimap.put(FLAG_C, "c2");
+
+        // If we don't check C, it doesn't matter
+        assertDoesNotThrow(() -> multimap.verifyNoDuplicateFlagsFor(FLAG_A, FLAG_B));
+        assertDoesNotThrow(() -> multimap.verifyNoDuplicateFlagsFor(FLAG_A));
+        assertDoesNotThrow(() -> multimap.verifyNoDuplicateFlagsFor(FLAG_B));
+    }
+
+    @Test
+    public void verifyNoDuplicateFlagsFor_hasDuplicates_exceptionThrown() {
+        ArgumentMultimap multimap = new ArgumentMultimap();
+        multimap.put(FLAG_A, "a");
+        multimap.put(FLAG_C, "c1");
+        multimap.put(FLAG_C, "c2");
+
+        // If we do check C, we must throw an exception
+        assertThrows(ParseException.class, () -> multimap.verifyNoDuplicateFlagsFor(FLAG_C));
+        assertThrows(ParseException.class, () -> multimap.verifyNoDuplicateFlagsFor(FLAG_A, FLAG_C));
+        assertThrows(ParseException.class, () -> multimap.verifyNoDuplicateFlagsFor(FLAG_B, FLAG_C));
+        assertThrows(ParseException.class, () -> multimap.verifyNoDuplicateFlagsFor(FLAG_A, FLAG_B, FLAG_C));
+    }
+
+
+    @Test
+    public void verifyNoExtraneousFlagsOnTopOf_noExtras_exceptionNotThrown() {
+        ArgumentMultimap multimap = new ArgumentMultimap();
+        multimap.put(FLAG_A, "a");
+        multimap.put(FLAG_B, "b1");
+        multimap.put(FLAG_B, "b2");
+
+        assertDoesNotThrow(() -> multimap.verifyNoExtraneousFlagsOnTopOf(FLAG_A, FLAG_B)); // exact match is ok
+        assertDoesNotThrow(() -> multimap.verifyNoExtraneousFlagsOnTopOf(FLAG_A, FLAG_B, FLAG_C)); // superset is ok
+    }
+
+    @Test
+    public void verifyNoExtraneousFlagsOnTopOf_hasExtras_exceptionThrown() {
+        ArgumentMultimap multimap = new ArgumentMultimap();
+        multimap.put(FLAG_A, "a");
+        multimap.put(FLAG_B, "b1");
+        multimap.put(FLAG_B, "b2");
+
+        assertThrows(ParseException.class, () -> multimap.verifyNoExtraneousFlagsOnTopOf(FLAG_A)); // extra B
+        assertThrows(ParseException.class, () -> multimap.verifyNoExtraneousFlagsOnTopOf(FLAG_B)); // extra A
+        assertThrows(ParseException.class, () -> multimap.verifyNoExtraneousFlagsOnTopOf(FLAG_C)); // extra A, B
+        assertThrows(ParseException.class, () -> multimap.verifyNoExtraneousFlagsOnTopOf(FLAG_A, FLAG_C)); // extra B
+        assertThrows(ParseException.class, () -> multimap.verifyNoExtraneousFlagsOnTopOf(FLAG_B, FLAG_C)); // extra A
+    }
+
+
+    @Test
+    public void verifyAllEmptyValuesAssignedFor_allEmpty_exceptionNotThrown() {
+        ArgumentMultimap multimap = new ArgumentMultimap();
+        multimap.put(FLAG_A, "");
+        multimap.put(FLAG_A, "  ");
+        multimap.put(FLAG_A, null);
+        multimap.put(FLAG_B, "bb");
+        multimap.put(FLAG_B, "bbb");
+        multimap.put(FLAG_C, "");
+
+        // A, C, D are empty
+        assertDoesNotThrow(() -> multimap.verifyAllEmptyValuesAssignedFor(FLAG_A));
+        assertDoesNotThrow(() -> multimap.verifyAllEmptyValuesAssignedFor(FLAG_C));
+        assertDoesNotThrow(() -> multimap.verifyAllEmptyValuesAssignedFor(FLAG_D));
+        assertDoesNotThrow(() -> multimap.verifyAllEmptyValuesAssignedFor(FLAG_A, FLAG_C));
+        assertDoesNotThrow(() -> multimap.verifyAllEmptyValuesAssignedFor(FLAG_A, FLAG_D));
+        assertDoesNotThrow(() -> multimap.verifyAllEmptyValuesAssignedFor(FLAG_D, FLAG_C));
+        assertDoesNotThrow(() -> multimap.verifyAllEmptyValuesAssignedFor(FLAG_A, FLAG_C, FLAG_D));
+    }
+
+    @Test
+    public void verifyAllEmptyValuesAssignedFor_someNonEmpty_exceptionThrown() {
+        ArgumentMultimap multimap = new ArgumentMultimap();
+        multimap.put(FLAG_A, "");
+        multimap.put(FLAG_A, "A");
+        multimap.put(FLAG_A, "  ");
+        multimap.put(FLAG_B, "B");
+
+        // A and B aren't empty
+        assertThrows(ParseException.class, () -> multimap.verifyAllEmptyValuesAssignedFor(FLAG_A));
+        assertThrows(ParseException.class, () -> multimap.verifyAllEmptyValuesAssignedFor(FLAG_B));
+        assertThrows(ParseException.class, () -> multimap.verifyAllEmptyValuesAssignedFor(FLAG_A, FLAG_B));
+        assertThrows(ParseException.class, () -> multimap.verifyAllEmptyValuesAssignedFor(FLAG_A, FLAG_C));
+        assertThrows(ParseException.class, () -> multimap.verifyAllEmptyValuesAssignedFor(FLAG_D, FLAG_C, FLAG_B));
+        assertThrows(ParseException.class, () -> multimap.verifyAllEmptyValuesAssignedFor(FLAG_C, FLAG_B, FLAG_A));
+    }
+
+
+}

--- a/src/test/java/seedu/address/logic/parser/ArgumentMultimapTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentMultimapTest.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/seedu/address/testutil/ContactUtil.java
+++ b/src/test/java/seedu/address/testutil/ContactUtil.java
@@ -32,12 +32,12 @@ public class ContactUtil {
      */
     public static String getContactDetails(Contact contact) {
         StringBuilder sb = new StringBuilder();
-        sb.append(FLAG_NAME + contact.getName().fullName + " ");
-        sb.append(FLAG_ID + contact.getId().value + " ");
-        sb.append(FLAG_PHONE + contact.getPhone().value + " ");
-        sb.append(FLAG_EMAIL + contact.getEmail().value + " ");
-        sb.append(FLAG_ADDRESS + contact.getAddress().value + " ");
-        sb.append(FLAG_URL + contact.getUrl().value + " ");
+        sb.append(FLAG_NAME + " " + contact.getName().fullName + " ");
+        sb.append(FLAG_ID + " " + contact.getId().value + " ");
+        sb.append(FLAG_PHONE + " " + contact.getPhone().value + " ");
+        sb.append(FLAG_EMAIL + " " + contact.getEmail().value + " ");
+        sb.append(FLAG_ADDRESS + " " + contact.getAddress().value + " ");
+        sb.append(FLAG_URL + " " + contact.getUrl().value + " ");
         contact.getTags().stream().forEach(
             s -> sb.append(FLAG_TAG + s.tagName + " ")
         );
@@ -49,17 +49,17 @@ public class ContactUtil {
      */
     public static String getEditContactDescriptorDetails(EditContactDescriptor descriptor) {
         StringBuilder sb = new StringBuilder();
-        descriptor.getName().ifPresent(name -> sb.append(FLAG_NAME).append(name.fullName).append(" "));
-        descriptor.getId().ifPresent(id -> sb.append(FLAG_ID).append(id.value).append(" "));
-        descriptor.getPhone().ifPresent(phone -> sb.append(FLAG_PHONE).append(phone.value).append(" "));
-        descriptor.getEmail().ifPresent(email -> sb.append(FLAG_EMAIL).append(email.value).append(" "));
-        descriptor.getAddress().ifPresent(address -> sb.append(FLAG_ADDRESS).append(address.value).append(" "));
+        descriptor.getName().ifPresent(name -> sb.append(FLAG_NAME).append(" ").append(name.fullName).append(" "));
+        descriptor.getId().ifPresent(id -> sb.append(FLAG_ID).append(" ").append(id.value).append(" "));
+        descriptor.getPhone().ifPresent(phone -> sb.append(FLAG_PHONE).append(" ").append(phone.value).append(" "));
+        descriptor.getEmail().ifPresent(email -> sb.append(FLAG_EMAIL).append(" ").append(email.value).append(" "));
+        descriptor.getAddress().ifPresent(address -> sb.append(FLAG_ADDRESS).append(" ").append(address.value).append(" "));
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {
                 sb.append(FLAG_TAG);
             } else {
-                tags.forEach(s -> sb.append(FLAG_TAG).append(s.tagName).append(" "));
+                tags.forEach(s -> sb.append(FLAG_TAG).append(" ").append(s.tagName).append(" "));
             }
         }
         return sb.toString();

--- a/src/test/java/seedu/address/testutil/ContactUtil.java
+++ b/src/test/java/seedu/address/testutil/ContactUtil.java
@@ -53,7 +53,8 @@ public class ContactUtil {
         descriptor.getId().ifPresent(id -> sb.append(FLAG_ID).append(" ").append(id.value).append(" "));
         descriptor.getPhone().ifPresent(phone -> sb.append(FLAG_PHONE).append(" ").append(phone.value).append(" "));
         descriptor.getEmail().ifPresent(email -> sb.append(FLAG_EMAIL).append(" ").append(email.value).append(" "));
-        descriptor.getAddress().ifPresent(address -> sb.append(FLAG_ADDRESS).append(" ").append(address.value).append(" "));
+        descriptor.getAddress().ifPresent(address ->
+                sb.append(FLAG_ADDRESS).append(" ").append(address.value).append(" "));
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {


### PR DESCRIPTION
This changes argument tokenization such that it will parse all flags with the matching default syntax and any explicitly specified flags.

Additionally, whitespace must now surround the flags for them to be valid.

Extra convenience methods are added to simplify new operations that can be useful for commands thanks to this refactor.

This closes #35 