### PR TITLE
Improve `ArgumentMultimap`

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -23,6 +23,8 @@ public class Messages {
             "Extra irrelevant options found in the command: ";
     public static final String MESSAGE_UNEXPECTED_NON_EMPTY_FIELDS =
             "The following options may not have any value: ";
+    public static final String MESSAGE_SIMULTANEOUS_USE_DISALLOWED_FIELDS =
+            "The following options conflict and cannot be set together: ";
 
     public static final String MESSAGE_INVALID_FIELD =
             "The term '%s' is not a valid option!";
@@ -58,7 +60,18 @@ public class Messages {
                 Stream.of(nonEmptyValuedFlags).map(Flag::toString).collect(Collectors.toSet());
 
         return MESSAGE_UNEXPECTED_NON_EMPTY_FIELDS + String.join(" ", nonEmptyValuedFields);
+    }
 
+    /**
+     * Returns an error message indicating the flags should not exist in the same command together.
+     */
+    public static String getErrorMessageForSimultaneousUseDisallowedFlags(Flag... conflictingFlags) {
+        assert conflictingFlags.length > 1;
+
+        Set<String> conflictingFields =
+                Stream.of(conflictingFlags).map(Flag::toString).collect(Collectors.toSet());
+
+        return MESSAGE_SIMULTANEOUS_USE_DISALLOWED_FIELDS + String.join(" ", conflictingFields);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -38,7 +38,7 @@ public class Messages {
         Set<String> duplicateFields =
                 Stream.of(duplicateFlags).map(Flag::toString).collect(Collectors.toSet());
 
-        return MESSAGE_DUPLICATE_FIELDS + String.join(" ", duplicateFields);
+        return MESSAGE_DUPLICATE_FIELDS + String.join(", ", duplicateFields);
     }
 
     /**
@@ -50,16 +50,19 @@ public class Messages {
         Set<String> extraneousFields =
                 Stream.of(extraneousFlags).map(Flag::toString).collect(Collectors.toSet());
 
-        return MESSAGE_EXTRA_FIELDS + String.join(" ", extraneousFields);
+        return MESSAGE_EXTRA_FIELDS + String.join(", ", extraneousFields);
     }
 
+    /**
+     * Returns an error message indicating the flags have unexpected values.
+     */
     public static String getErrorMessageForNonEmptyValuedFlags(Flag... nonEmptyValuedFlags) {
         assert nonEmptyValuedFlags.length > 0;
 
         Set<String> nonEmptyValuedFields =
                 Stream.of(nonEmptyValuedFlags).map(Flag::toString).collect(Collectors.toSet());
 
-        return MESSAGE_UNEXPECTED_NON_EMPTY_FIELDS + String.join(" ", nonEmptyValuedFields);
+        return MESSAGE_UNEXPECTED_NON_EMPTY_FIELDS + String.join(", ", nonEmptyValuedFields);
     }
 
     /**
@@ -71,7 +74,7 @@ public class Messages {
         Set<String> conflictingFields =
                 Stream.of(conflictingFlags).map(Flag::toString).collect(Collectors.toSet());
 
-        return MESSAGE_SIMULTANEOUS_USE_DISALLOWED_FIELDS + String.join(" ", conflictingFields);
+        return MESSAGE_SIMULTANEOUS_USE_DISALLOWED_FIELDS + String.join(", ", conflictingFields);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -169,4 +169,18 @@ public class ArgumentMultimap {
             throw new ParseException(Messages.getErrorMessageForNonEmptyValuedFlags(flagsWithUsefulValues));
         }
     }
+
+    /**
+     * Throws a {@code ParseException} if there are more than one of the given {@code flags} simultanouesly
+     * put in this map, i.e., they cannot be used together.
+     */
+    public void verifyOnlyOneOfFlagsUsedOutOf(Flag... flags) throws ParseException {
+        Flag[] existingFlags = Stream.of(flags).distinct()
+                .filter(flag -> argMultimap.containsKey(flag) && argMultimap.get(flag).size() > 1)
+                .toArray(Flag[]::new);
+
+        if (existingFlags.length > 1) {
+            throw new ParseException(Messages.getErrorMessageForSimultaneousUseDisallowedFlags(existingFlags));
+        }
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -174,9 +174,9 @@ public class ArgumentMultimap {
      * Throws a {@code ParseException} if there are more than one of the given {@code flags} simultanouesly
      * put in this map, i.e., they cannot be used together.
      */
-    public void verifyOnlyOneOfFlagsUsedOutOf(Flag... flags) throws ParseException {
+    public void verifyAtMostOneOfFlagsUsedOutOf(Flag... flags) throws ParseException {
         Flag[] existingFlags = Stream.of(flags).distinct()
-                .filter(flag -> argMultimap.containsKey(flag) && argMultimap.get(flag).size() > 1)
+                .filter(flag -> argMultimap.containsKey(flag) && argMultimap.get(flag).size() > 0)
                 .toArray(Flag[]::new);
 
         if (existingFlags.length > 1) {


### PR DESCRIPTION
This adds some helper methods for more convenient parsing, and improves the test cases for the class. It also fixes some formatting issues for errors thrown in this class.
