### PR TITLE
Unify `INDEX/ID` preamble behavior from `edit` to `delete` and `apply`

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -195,7 +195,7 @@ Examples:
 _{To be updated...}_
 
 Deletes the specified contact from the address book and its associated contacts if specified.
-Format: `delete INDEX [--recursive]` or `delete --id ID [--recursive]`
+Format: `delete INDEX/ID [--recursive]`
 
 * `INDEX` refers to the index number shown on the list and must be a positive integer.
 * Deletes the person with id `ID` if specified, ignoring if the contact is shown in the list.
@@ -203,7 +203,7 @@ Format: `delete INDEX [--recursive]` or `delete --id ID [--recursive]`
 
 Examples:
 * `delete 1` deletes the 1st contact in the list of contacts shown.
-* `delete --id 045f` deletes the contact with id `045f` in the address book.
+* `delete amazon-sg` deletes the contact with id `amazon-sg` in the address book.
 * `delete 1 --recursive` deletes the 1st contact along with other contacts associated under it.
 
 

--- a/src/main/java/seedu/address/logic/autocomplete/AutocompleteGenerator.java
+++ b/src/main/java/seedu/address/logic/autocomplete/AutocompleteGenerator.java
@@ -156,12 +156,16 @@ public class AutocompleteGenerator {
             AutocompleteSupplier supplier,
             Model model
     ) {
-        return supplier.getValidValues(
-                Flag.parseOptional(
-                        command.getLastConfirmedFlagString().orElse(null)
-                ).orElse(null),
-                model
+        Optional<String> flagString = command.getLastConfirmedFlagString();
+        if (flagString.isEmpty()) {
+            return supplier.getValidValues(null, command, model);
+        }
+
+        Optional<Flag> targetFlag = Flag.findMatch(
+                flagString.get(),
+                supplier.getAllPossibleFlags().toArray(Flag[]::new)
         );
+        return targetFlag.flatMap(f -> supplier.getValidValues(f, command, model));
     }
 
 }

--- a/src/main/java/seedu/address/logic/autocomplete/AutocompleteSupplier.java
+++ b/src/main/java/seedu/address/logic/autocomplete/AutocompleteSupplier.java
@@ -107,14 +107,15 @@ public class AutocompleteSupplier {
      * and not just the lack of completion suggestions.
      *
      * @param flag The flag to check against. This may be null to represent the preamble.
+     * @param currentCommand The current command structure. This should not be null.
      * @param model The model to be supplied for generation. This may be null if model-data is not essential
      *              for any purpose.
      */
-    public Optional<Stream<String>> getValidValues(Flag flag, Model model) {
+    public Optional<Stream<String>> getValidValues(Flag flag, PartitionedCommand currentCommand, Model model) {
         try {
             return Optional.ofNullable(
-                    this.values.getOrDefault(flag, m -> Stream.of())
-            ).map(x -> x.apply(model));
+                    this.values.getOrDefault(flag, (c, m) -> Stream.empty())
+            ).map(flagValueSupplier -> flagValueSupplier.apply(currentCommand, model));
 
         } catch (RuntimeException e) {
             // Guard against errors like NPEs due to supplied lambdas not handling them.

--- a/src/main/java/seedu/address/logic/autocomplete/FlagValueSupplier.java
+++ b/src/main/java/seedu/address/logic/autocomplete/FlagValueSupplier.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.autocomplete;
 
-
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 import seedu.address.model.Model;
@@ -10,17 +9,41 @@ import seedu.address.model.Model;
  * Supplies a list of values for auto-completing a flag's value, given the model.
  *
  * <p>
- * Both the input and output {@link Model} may be null.
+ * Any implementation of {@link FlagValueSupplier} must conform to the specifications noted on the
+ * {@link #apply} method.
  * </p>
- * <ul>
- *     <li>If the model is available, use the available information to best compute a stream of values.</li>
- *     <li>If the model is null, make do with the available information to return the result.</li>
- * </ul>
- * <ul>
- *     <li>If there are no known values to complete, return an empty list.</li>
- *     <li>If there are no values to consider at all (e.g., flag doesn't accept values), return null.</li>
- * </ul>
- * */
-public interface FlagValueSupplier extends Function<Model, Stream<String>> {
-    // Inherited implementation.
+ */
+public interface FlagValueSupplier extends BiFunction<PartitionedCommand, Model, Stream<String>> {
+
+
+    /**
+     * Returns a stream of possible values that a particular flag could take.
+     *
+     * <p>
+     *     This will always return all possible values - any additional conditional filters like prefix matching
+     *     should be up to the receiver of the stream to apply. The {@code currentCommand} field is required
+     *     in case the supplier wants to provide entirely different set of suggestions based on the initial input
+     *     (e.g., omit suggestions when a numeric index is provided, but provide suggestions for standard text).
+     * </p>
+     *
+     * <p>
+     *     There are a two forms of possible return results:
+     *     <ul>
+     *         <li>
+     *             If the returned stream is non-empty, it indicates suggestions where
+     *             {@code currentValue} could be replaced with.
+     *         </li>
+     *         <li>If the returned stream is empty, it indicates the lack of suggestions.</li>
+     *         <li>If the returned stream given is null, it indicates this flag should not have a value.</li>
+     *     </ul>
+     * </p>
+     *
+     * @param currentCommand The current command typed so far. Should never be null.
+     * @param model          The model that can be used. May be null.
+     *
+     * @return A stream of suggestions (can be an empty stream for "nothing to suggest"),
+     *         or null indicating to skip suggestions entirely (for "this should not have any value").
+     */
+    @Override
+    Stream<String> apply(PartitionedCommand currentCommand, Model model);
 }

--- a/src/main/java/seedu/address/logic/autocomplete/PartitionedCommand.java
+++ b/src/main/java/seedu/address/logic/autocomplete/PartitionedCommand.java
@@ -11,7 +11,7 @@ import seedu.address.logic.parser.Flag;
 /**
  * A wrapper around a command string as partitions, useful for computing results for autocompletion.
  */
-class PartitionedCommand {
+public class PartitionedCommand {
     private final String name;
     private final String middleText;
     private final String trailingText;
@@ -103,6 +103,14 @@ class PartitionedCommand {
      */
     public String getTrailingText() {
         return trailingText;
+    }
+
+    /**
+     * Gets the trailing part of the text that should be replaced with an autocompletion value.
+     * Equivalent to {@link #getTrailingText}.
+     */
+    public String getAutocompletableText() {
+        return getTrailingText();
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -63,18 +63,19 @@ public class AddCommand extends Command {
                     AutocompleteConstraint.where(FLAG_RECRUITER)
                             .isPrerequisiteFor(FLAG_ORGANIZATION_ID)
             ))
-    ).configureValueMap(m -> {
+    ).configureValueMap(map -> {
         // Add value autocompletion for:
-        m.put(FLAG_ORGANIZATION_ID,
-                model -> model.getAddressBook().getContactList().stream()
-                        .filter(c -> c.getType() == Type.ORGANIZATION)
-                        .map(o -> o.getId().value)
+        map.put(FLAG_ORGANIZATION_ID, (command, model) -> model.getAddressBook()
+                .getContactList()
+                .stream()
+                .filter(c -> c.getType() == Type.ORGANIZATION)
+                .map(o -> o.getId().value)
         );
 
         // Disable value autocompletion for:
-        m.put(null /* preamble */, null);
-        m.put(FLAG_ORGANIZATION, null);
-        m.put(FLAG_RECRUITER, null);
+        map.put(null /* preamble */, null);
+        map.put(FLAG_ORGANIZATION, null);
+        map.put(FLAG_RECRUITER, null);
     });
 
 

--- a/src/main/java/seedu/address/logic/commands/ApplyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ApplyCommand.java
@@ -40,13 +40,22 @@ public class ApplyCommand extends Command {
                     FLAG_DEADLINE, FLAG_STAGE, FLAG_STATUS,
                     FLAG_ID
             )
-    ).configureValueMap(m -> {
+    ).configureValueMap(map -> {
         // Add value autocompletion data for:
-        m.put(FLAG_ID, model -> model.getAddressBook().getContactList().stream()
+        map.put(FLAG_ID, (command, model)
+                -> model.getAddressBook()
+                .getContactList()
+                .stream()
                 .filter(c -> c.getType() == Type.ORGANIZATION)
                 .map(o -> o.getId().value));
-        m.put(FLAG_STAGE, model -> Arrays.stream(ApplicationStage.values()).map(ApplicationStage::toString));
-        m.put(FLAG_STATUS, model -> Arrays.stream(JobStatus.values()).map(JobStatus::toString));
+
+        map.put(FLAG_STAGE, (command, model)
+                -> Arrays.stream(ApplicationStage.values())
+                .map(ApplicationStage::toString));
+
+        map.put(FLAG_STATUS, (command, model)
+                -> Arrays.stream(JobStatus.values())
+                .map(JobStatus::toString));
     });
 
     public static final String MESSAGE_USAGE = "Adds a new job application.\n"

--- a/src/main/java/seedu/address/logic/commands/ApplyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ApplyCommand.java
@@ -2,17 +2,18 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.parser.CliSyntax.FLAG_DEADLINE;
 import static seedu.address.logic.parser.CliSyntax.FLAG_DESCRIPTION;
-import static seedu.address.logic.parser.CliSyntax.FLAG_ID;
 import static seedu.address.logic.parser.CliSyntax.FLAG_STAGE;
 import static seedu.address.logic.parser.CliSyntax.FLAG_STATUS;
 import static seedu.address.logic.parser.CliSyntax.FLAG_TITLE;
 
 import java.util.Arrays;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.autocomplete.AutocompleteSupplier;
 import seedu.address.logic.autocomplete.data.AutocompleteDataSet;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -37,17 +38,27 @@ public class ApplyCommand extends Command {
     public static final AutocompleteSupplier AUTOCOMPLETE_SUPPLIER = AutocompleteSupplier.from(
             AutocompleteDataSet.onceForEachOf(
                     FLAG_TITLE, FLAG_DESCRIPTION,
-                    FLAG_DEADLINE, FLAG_STAGE, FLAG_STATUS,
-                    FLAG_ID
+                    FLAG_DEADLINE, FLAG_STAGE, FLAG_STATUS
             )
     ).configureValueMap(map -> {
         // Add value autocompletion data for:
-        map.put(FLAG_ID, (command, model)
-                -> model.getAddressBook()
-                .getContactList()
-                .stream()
-                .filter(c -> c.getType() == Type.ORGANIZATION)
-                .map(o -> o.getId().value));
+        map.put(null /* preamble */, (command, model) -> {
+
+            String partialText = command.getAutocompletableText();
+            if (partialText.isEmpty() || StringUtil.isNonZeroUnsignedInteger(partialText)) {
+                // Preamble is likely of type Index
+                return Stream.empty();
+
+            } else {
+                // Preamble is likely of type Id
+                // * Constraint: Applications must be towards organizations
+                return model.getAddressBook()
+                        .getContactList()
+                        .stream()
+                        .filter(c -> c.getType() == Type.ORGANIZATION)
+                        .map(o -> o.getId().value);
+            }
+        });
 
         map.put(FLAG_STAGE, (command, model)
                 -> Arrays.stream(ApplicationStage.values())
@@ -60,8 +71,7 @@ public class ApplyCommand extends Command {
 
     public static final String MESSAGE_USAGE = "Adds a new job application.\n"
             + "Parameters: "
-            + "INDEX (must be a positive integer) "
-            + FLAG_ID + " ID "
+            + "INDEX/ID "
             + FLAG_TITLE + " TITLE " // Title
             + FLAG_DESCRIPTION + " DESCRIPTION " // Description
             + FLAG_DEADLINE + " DEADLINE: DD-MM-YYYY " // Deadline

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,13 +1,14 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.FLAG_ID;
 import static seedu.address.logic.parser.CliSyntax.FLAG_RECURSIVE;
 
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.autocomplete.AutocompleteSupplier;
@@ -15,7 +16,6 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.Id;
-import seedu.address.model.contact.Type;
 
 /**
  * Deletes a contact identified using its displayed index or its contact id from the address book.
@@ -25,30 +25,35 @@ public class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
     public static final AutocompleteSupplier AUTOCOMPLETE_SUPPLIER = AutocompleteSupplier.fromUniqueFlags(
-            FLAG_ID, FLAG_RECURSIVE
+            FLAG_RECURSIVE
     ).configureValueMap(map -> {
         // Add value autocompletion data for:
-        map.put(FLAG_ID, (command, model) -> model.getAddressBook()
-                .getContactList()
-                .stream()
-                .filter(c -> c.getType() == Type.ORGANIZATION)
-                .map(o -> o.getId().value)
-        );
+        map.put(null /* preamble */, (command, model) -> {
 
-        // Disable value autocompletion for:
-        map.put(FLAG_RECURSIVE, null);
+            String partialText = command.getAutocompletableText();
+            if (partialText.isEmpty() || StringUtil.isNonZeroUnsignedInteger(partialText)) {
+                // Preamble is likely of type Index
+                return Stream.empty();
+
+            } else {
+                // Preamble is likely of type Id
+                return model.getAddressBook()
+                        .getContactList()
+                        .stream()
+                        .map(o -> o.getId().value);
+            }
+        });
     });
 
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the contact identified by the index number used in the displayed contact list.\n"
             + "Parameters: "
-            + "INDEX (must be a positive integer) "
-            + FLAG_ID + " ID "
-            + FLAG_RECURSIVE + " RECURSIVE "
+            + "INDEX/ID "
+            + "[" + FLAG_RECURSIVE + "] "
             + "\n"
             + "Example 1: " + COMMAND_WORD + " 1\n"
-            + "Example 2: " + COMMAND_WORD + " --id 0d0h4\n"
+            + "Example 2: " + COMMAND_WORD + " amazon-sg\n"
             + "Example 3: " + COMMAND_WORD + " 1 --recursive\n";
 
     public static final String MESSAGE_DELETE_CONTACT_SUCCESS = "Deleted Contact: %1$s";

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.Id;
+import seedu.address.model.contact.Type;
 
 /**
  * Deletes a contact identified using its displayed index or its contact id from the address book.
@@ -25,12 +26,17 @@ public class DeleteCommand extends Command {
 
     public static final AutocompleteSupplier AUTOCOMPLETE_SUPPLIER = AutocompleteSupplier.fromUniqueFlags(
             FLAG_ID, FLAG_RECURSIVE
-    ).configureValueMap(m -> {
+    ).configureValueMap(map -> {
         // Add value autocompletion data for:
-        m.put(FLAG_ID, model -> model.getAddressBook().getContactList().stream().map(c -> c.getId().value));
+        map.put(FLAG_ID, (command, model) -> model.getAddressBook()
+                .getContactList()
+                .stream()
+                .filter(c -> c.getType() == Type.ORGANIZATION)
+                .map(o -> o.getId().value)
+        );
 
         // Disable value autocompletion for:
-        m.put(FLAG_RECURSIVE, null);
+        map.put(FLAG_RECURSIVE, null);
     });
 
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -19,9 +19,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
+import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.autocomplete.AutocompleteSupplier;
@@ -57,7 +59,30 @@ public class EditCommand extends Command {
                     FLAG_ORGANIZATION_ID
             ),
             AutocompleteDataSet.anyNumberOf(FLAG_TAG)
-    );
+    ).configureValueMap(map -> {
+        // Add value autocompletion data for:
+        map.put(null /* preamble*/, (command, model) -> {
+
+            String partialText = command.getAutocompletableText();
+            if (partialText.isEmpty() || StringUtil.isNonZeroUnsignedInteger(partialText)) {
+                // Preamble is likely of type Index
+                return Stream.empty();
+
+            } else {
+                // Preamble is likely of type Id
+                return model.getAddressBook()
+                        .getContactList()
+                        .stream()
+                        .map(o -> o.getId().value);
+            }
+        });
+        map.put(FLAG_ORGANIZATION_ID, (command, model) -> model.getAddressBook()
+                .getContactList()
+                .stream()
+                .filter(c -> c.getType() == Type.ORGANIZATION)
+                .map(o -> o.getId().value)
+        );
+    });
 
     public static final String MESSAGE_ORGANIZATION_USAGE = "Edits an organization.\n"
             + "Parameters: INDEX/ID "

--- a/src/main/java/seedu/address/logic/parser/ApplyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ApplyCommandParser.java
@@ -33,6 +33,11 @@ public class ApplyCommandParser implements Parser<ApplyCommand> {
                         ApplyCommand.AUTOCOMPLETE_SUPPLIER.getAllPossibleFlags().toArray(Flag[]::new)
                 );
 
+        if (argumentMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                    ApplyCommand.MESSAGE_USAGE));
+        }
+
         Object indexXorId = ParserUtil.parseIndexXorId(argumentMultimap.getPreamble());
 
         Optional<String> title = argumentMultimap.getValue(FLAG_TITLE);
@@ -45,6 +50,7 @@ public class ApplyCommandParser implements Parser<ApplyCommand> {
             throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
                     ApplyCommand.MESSAGE_USAGE));
         }
+
         // TODO: Tech debt - Use Parserutil.parseOptionally
         return new ApplyCommand(
                 indexXorId instanceof Id ? (Id) indexXorId : null,

--- a/src/main/java/seedu/address/logic/parser/ApplyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ApplyCommandParser.java
@@ -2,16 +2,17 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.parser.CliSyntax.FLAG_DEADLINE;
 import static seedu.address.logic.parser.CliSyntax.FLAG_DESCRIPTION;
-import static seedu.address.logic.parser.CliSyntax.FLAG_ID;
 import static seedu.address.logic.parser.CliSyntax.FLAG_STAGE;
 import static seedu.address.logic.parser.CliSyntax.FLAG_STATUS;
 import static seedu.address.logic.parser.CliSyntax.FLAG_TITLE;
 
 import java.util.Optional;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.ApplyCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.contact.Id;
 
 
 /**
@@ -32,28 +33,13 @@ public class ApplyCommandParser implements Parser<ApplyCommand> {
                         ApplyCommand.AUTOCOMPLETE_SUPPLIER.getAllPossibleFlags().toArray(Flag[]::new)
                 );
 
-        boolean hasIndex = !argumentMultimap.getPreamble().isEmpty();
-        boolean hasId = argumentMultimap.getValue(FLAG_ID).isPresent();
+        Object indexXorId = ParserUtil.parseIndexXorId(argumentMultimap.getPreamble());
 
-        String id = argumentMultimap.getValue(FLAG_ID).orElse(null);
-        String index = hasIndex ? argumentMultimap.getPreamble() : null;
         Optional<String> title = argumentMultimap.getValue(FLAG_TITLE);
         Optional<String> description = argumentMultimap.getValue(FLAG_DESCRIPTION);
         Optional<String> stage = argumentMultimap.getValue(FLAG_STAGE);
         Optional<String> status = argumentMultimap.getValue(FLAG_STATUS);
         Optional<String> deadline = argumentMultimap.getValue(FLAG_DEADLINE);
-
-
-        if (hasId && hasIndex) {
-            throw new ParseException(
-                    String.format(Messages.MESSAGE_SIMULTANEOUS_USE_DISALLOWED_FIELDS + "Index, Id")
-            );
-        }
-
-        if (!hasId && !hasIndex) {
-            throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
-                    ApplyCommand.MESSAGE_USAGE));
-        }
 
         if (title.isEmpty()) {
             throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
@@ -61,8 +47,8 @@ public class ApplyCommandParser implements Parser<ApplyCommand> {
         }
         // TODO: Tech debt - Use Parserutil.parseOptionally
         return new ApplyCommand(
-                hasId ? ParserUtil.parseId(id) : null,
-                hasIndex ? ParserUtil.parseIndex(index) : null,
+                indexXorId instanceof Id ? (Id) indexXorId : null,
+                indexXorId instanceof Index ? (Index) indexXorId : null,
                 ParserUtil.parseJobTitle(title.get()),
                 description.isPresent() ? ParserUtil.parseJobDescription(description.get()) : null,
                 deadline.isPresent() ? ParserUtil.parseDeadline(deadline.get()) : null,

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.FLAG_ID;
 import static seedu.address.logic.parser.CliSyntax.FLAG_RECURSIVE;
 
 import seedu.address.commons.core.index.Index;
@@ -24,40 +23,24 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
                 ArgumentTokenizer.tokenize(args,
                         DeleteCommand.AUTOCOMPLETE_SUPPLIER.getAllPossibleFlags().toArray(Flag[]::new));
 
-        boolean hasIndex = !argumentMultimap.getPreamble().isEmpty();
-        boolean hasId = argumentMultimap.getValue(FLAG_ID).isPresent();
+        if (argumentMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        }
+
+        Object indexXorId = ParserUtil.parseIndexXorId(argumentMultimap.getPreamble());
         boolean isRecursive = argumentMultimap.getValue(FLAG_RECURSIVE).isPresent();
 
-        if (hasIndex) {
-            return parseDeleteIndexCommand(argumentMultimap.getPreamble(), isRecursive);
+        if (indexXorId instanceof Index) {
+            return DeleteCommand.selectIndex((Index) indexXorId, isRecursive);
         }
 
-        if (hasId) {
-            return parseDeleteIdCommand(argumentMultimap.getValue(FLAG_ID).get(), isRecursive);
+        if (indexXorId instanceof Id) {
+            return DeleteCommand.selectId((Id) indexXorId, isRecursive);
         }
-        throw new ParseException(
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+
+        assert false : "If indexXorId is neither Index nor Id, then ParserUtil should've thrown ParseException!";
+        throw new IllegalStateException();
     }
 
-    private static DeleteCommand parseDeleteIdCommand(String idString, boolean isRecursive) throws ParseException {
-        Id id;
-        try {
-            id = ParserUtil.parseId(idString);
-            return DeleteCommand.selectId(id, isRecursive);
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
-        }
-    }
-
-    private static DeleteCommand parseDeleteIndexCommand(String indexStr, boolean isRecursive) throws ParseException {
-        Index index;
-        try {
-            index = ParserUtil.parseIndex(indexStr);
-            return DeleteCommand.selectIndex(index, isRecursive);
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
-        }
-    }
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -50,13 +50,21 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         try {
             String preambleStr = argMultimap.getPreamble();
-            if (preambleStr.matches("^[A-Za-z].*")) {
-                targetId = ParserUtil.parseId(preambleStr);
+            Object indexXorId = ParserUtil.parseIndexXorId(preambleStr);
+
+            if (indexXorId instanceof Id) {
+                targetId = (Id) indexXorId;
                 index = null;
-            } else {
-                index = ParserUtil.parseIndex(preambleStr);
+            } else if (indexXorId instanceof Index) {
+                index = (Index) indexXorId;
                 targetId = null;
+            } else {
+                assert false
+                        : "If indexXorId is neither an Index nor an Id, "
+                        + "ParserUtil should've thrown ParseException!";
+                throw new IllegalStateException();
             }
+
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }

--- a/src/main/java/seedu/address/logic/parser/Flag.java
+++ b/src/main/java/seedu/address/logic/parser/Flag.java
@@ -93,7 +93,8 @@ public class Flag {
 
     /**
      * Parses the given string using the default prefix and postfix format into a {@link Flag}.
-     * This will work for both full flag strings and flag aliases.
+     * This will work for both full flag strings and flag aliases. However, this may not return the same result
+     * as an existing flag that has both a full value and alias pair - for those, try {@link #findMatch} instead.
      *
      * @param string The string to parse as a flag.
      * @return The corresponding {@link Flag} instance.

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -47,6 +47,39 @@ public class ParserUtil {
     }
 
     /**
+     * Parses a {@code String id} into an {@code Id} and returns it.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code id} is invalid.
+     */
+    public static Id parseId(String id) throws ParseException {
+        requireNonNull(id);
+        String trimmedId = id.trim();
+        if (!Id.isValidId(id)) {
+            throw new ParseException(Id.MESSAGE_CONSTRAINTS);
+        }
+        return new Id(trimmedId);
+    }
+
+    /**
+     * Parses a {@code String id} into a {@code Id} or {@code Index}, depending on the format of the string.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @return {@link Object} that is either an {@link Id} or an {@link Index} instance.
+     * @throws ParseException if the given {@code str} is neither an index nor an id.
+     */
+    public static Object parseIndexXorId(String str) throws ParseException {
+        String trimmedStr = str.trim();
+        Object result;
+        if (trimmedStr.matches("^[0-9]*$")) {
+            result = ParserUtil.parseIndex(trimmedStr);
+        } else {
+            result = ParserUtil.parseId(trimmedStr);
+        }
+        return result;
+    }
+
+    /**
      * Parses a {@code String name} into a {@code Name}.
      * Leading and trailing whitespaces will be trimmed.
      *
@@ -59,21 +92,6 @@ public class ParserUtil {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
         }
         return new Name(trimmedName);
-    }
-
-    /**
-     * Parses a {@code String id} into a {@code Status}.
-     * Leading and trailing whitespaces will be trimmed.
-     *
-     * @throws ParseException if the given {@code id} is invalid.
-     */
-    public static Id parseId(String id) throws ParseException {
-        requireNonNull(id);
-        String trimmedId = id.trim();
-        if (!Id.isValidId(id)) {
-            throw new ParseException(Id.MESSAGE_CONSTRAINTS);
-        }
-        return new Id(trimmedId);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/autocomplete/AutocompleteGeneratorTest.java
+++ b/src/test/java/seedu/address/logic/autocomplete/AutocompleteGeneratorTest.java
@@ -65,7 +65,8 @@ public class AutocompleteGeneratorTest {
                         AutocompleteConstraint.oneAmongAllOf(flagA1, flagA2)
                 ),
                 Map.of(
-                        flagA3, m -> Stream.of("apple", "banana", "car")
+                        flagA3, (c, m) -> Stream.of("apple", "banana", "car"),
+                        flagC1, (c, m) -> null
                 )
         );
 
@@ -145,6 +146,22 @@ public class AutocompleteGeneratorTest {
                 ),
                 new AutocompleteGenerator(supplier)
                         .generateCompletions("cmd -a x y --code z -o")
+                        .collect(Collectors.toList())
+        );
+
+        // autocomplete: --cde <flag>
+        assertEquals(
+                List.of(
+                        // Rationale: --cde does not accept values, so a next flag is immediately suggested
+                        "cmd --cde --aaa",
+                        "cmd --cde --abc",
+                        "cmd --cde --adg",
+                        "cmd --cde --book",
+                        "cmd --cde --cde",
+                        "cmd --cde --code"
+                ),
+                new AutocompleteGenerator(supplier)
+                        .generateCompletions("cmd --cde ")
                         .collect(Collectors.toList())
         );
 

--- a/src/test/java/seedu/address/logic/autocomplete/AutocompleteSupplierTest.java
+++ b/src/test/java/seedu/address/logic/autocomplete/AutocompleteSupplierTest.java
@@ -118,23 +118,31 @@ public class AutocompleteSupplierTest {
                         AutocompleteConstraint.oneAmongAllOf(FLAG_A, FLAG_B) // A & B cannot coexist
                 ),
                 Map.of(
-                        FLAG_A, m -> LIST_A.stream(),
-                        FLAG_B, m -> LIST_B.stream(),
-                        FLAG_C, m -> LIST_C.stream(),
-                        FLAG_D, m -> LIST_EMPTY.stream(),
-                        FLAG_F, m -> Stream.of(m.toString())
+                        FLAG_A, (c, m) -> LIST_A.stream(),
+                        FLAG_B, (c, m) -> LIST_B.stream(),
+                        FLAG_C, (c, m) -> LIST_C.stream(),
+                        FLAG_D, (c, m) -> LIST_EMPTY.stream(),
+                        FLAG_F, (c, m) -> Stream.of(m.toString())
                 )
         );
 
+        var emptyCommand = new PartitionedCommand("");
+
         // Should use the lambda's values
-        assertEquals(LIST_A, supplier.getValidValues(FLAG_A, null).get().collect(Collectors.toList()));
-        assertEquals(LIST_B, supplier.getValidValues(FLAG_B, null).get().collect(Collectors.toList()));
-        assertEquals(LIST_C, supplier.getValidValues(FLAG_C, null).get().collect(Collectors.toList()));
-        assertEquals(LIST_EMPTY, supplier.getValidValues(FLAG_D, null).get().collect(Collectors.toList()));
-        assertEquals(LIST_EMPTY, supplier.getValidValues(FLAG_E, null).get().collect(Collectors.toList()));
+        assertEquals(LIST_A, supplier.getValidValues(FLAG_A, emptyCommand, null)
+                .get().collect(Collectors.toList()));
+        assertEquals(LIST_B, supplier.getValidValues(FLAG_B, emptyCommand, null)
+                .get().collect(Collectors.toList()));
+        assertEquals(LIST_C, supplier.getValidValues(FLAG_C, emptyCommand, null)
+                .get().collect(Collectors.toList()));
+        assertEquals(LIST_EMPTY, supplier.getValidValues(FLAG_D, emptyCommand, null)
+                .get().collect(Collectors.toList()));
+        assertEquals(LIST_EMPTY, supplier.getValidValues(FLAG_E, emptyCommand, null)
+                .get().collect(Collectors.toList()));
 
         // NPEs should be caught if the lambda does not handle it
-        assertEquals(LIST_EMPTY, supplier.getValidValues(FLAG_F, null).get().collect(Collectors.toList()));
+        assertEquals(LIST_EMPTY, supplier.getValidValues(FLAG_F, emptyCommand, null)
+                .get().collect(Collectors.toList()));
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/AppParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AppParserTest.java
@@ -100,7 +100,7 @@ public class AppParserTest {
 
     @Test
     public void parseCommand_apply() throws Exception {
-        assertTrue(parser.parseCommand(ApplyCommand.COMMAND_WORD + " --id id_1 --title SWE") instanceof ApplyCommand);
+        assertTrue(parser.parseCommand(ApplyCommand.COMMAND_WORD + " id_1 --title SWE") instanceof ApplyCommand);
         assertTrue(parser.parseCommand(ApplyCommand.COMMAND_WORD + " 3 --title SWE") instanceof ApplyCommand);
     }
 

--- a/src/test/java/seedu/address/logic/parser/ApplyCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ApplyCommandParserTest.java
@@ -14,7 +14,7 @@ class ApplyCommandParserTest {
     private static final String VALID_ARGS_3 = "1 --title SWE --desc Pay: $100";
     private static final String VALID_ARGS_4 = "1 --title SWE --stage interview";
     private static final String VALID_ARGS_5 = "1 --title SWE --status pending";
-    private static final String VALID_ARGS_6 = "--id TEST_ID --title SWE";
+    private static final String VALID_ARGS_6 = "TEST_ID --title SWE";
     private static final String INVALID_ARGS_1 = "1";
     private static final String INVALID_ARGS_2 = "--title SWE";
 

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -27,6 +27,7 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "--recursive", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
This implements the `edit` command behavior of accepting both `INDEX` and `ID` in the preamble to that of the `delete` and `apply` commands.

It also unifies all of these commands to implement similar autocompletion when an `ID` input is detected.
