### PR TITLE
Update `Id` to synthesize values based on names if it is omitted

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -87,7 +87,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Optional<String> idString = argMultimap.getValue(FLAG_ID);
         Id id = idString.isPresent()
                 ? ParserUtil.parseId(idString.get())
-                : new Id();
+                : Id.synthesizeFrom(name.fullName);
 
         Phone phone = ParserUtil.parseOptionally(
                 argMultimap.getValue(FLAG_PHONE), ParserUtil::parsePhone);
@@ -111,7 +111,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Optional<String> idString = argMultimap.getValue(FLAG_ID);
         Id id = idString.isPresent()
                 ? ParserUtil.parseId(idString.get())
-                : new Id();
+                : Id.synthesizeFrom(name.fullName);
 
         Phone phone = ParserUtil.parseOptionally(
                 argMultimap.getValue(FLAG_PHONE), ParserUtil::parsePhone);

--- a/src/main/java/seedu/address/model/contact/Id.java
+++ b/src/main/java/seedu/address/model/contact/Id.java
@@ -3,6 +3,7 @@ package seedu.address.model.contact;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.Random;
 import java.util.UUID;
 
 /**
@@ -40,7 +41,56 @@ public class Id {
     }
 
     /**
-     * Returns true if a given string is a valid name.
+     * Synthesizes an {@link Id} from a given string.
+     */
+    public static Id synthesizeFrom(String input) {
+        if (input == null || input.isBlank()) {
+            return new Id();
+        }
+
+        String resultingIdString = input.trim().toLowerCase();
+
+        // Ensure leading letters
+        if (!resultingIdString.matches("^[a-zA-Z].*")) {
+            resultingIdString = "i-" + resultingIdString;
+        }
+
+        // Ensure no non-accepted characters
+        resultingIdString = resultingIdString
+                .replaceAll("[ \t\n]", "-")
+                .replaceAll("[^a-zA-Z0-9_\\-]", "x");
+
+        // Ensure no repeated _ or -
+        resultingIdString = resultingIdString
+                .replaceAll("(-_+|_-+)", "-")
+                .replaceAll("_{2,}", "_")
+                .replaceAll("-{2,}", "-");
+
+        // Add a random trailing 6-digit hex to minimize collisions
+        Random random = new Random();
+        int hexValue = random.nextInt(0x1_000_000);
+
+        if (resultingIdString.matches("(.*)[^_\\-]$")) {
+            // Append a trailing dash (if one isn't present) before the hex value
+            resultingIdString += "-";
+        }
+        resultingIdString += String.format("%06x", hexValue);
+
+        // Construct and return our new id
+        try {
+            return new Id(resultingIdString);
+        } catch (IllegalArgumentException e) {
+            // If we still fail due to an invalid format, generate a random one.
+            //
+            // Note: It is best to always synthesize user-friendly id values. So, if we have values that result in
+            //       parse errors, consider checking what cases have been missed and normalize them to the rules.
+            return new Id();
+        }
+    }
+
+
+    /**
+     * Returns true if a given string is a valid id.
      */
     public static boolean isValidId(String test) {
         return test.matches(VALIDATION_REGEX);

--- a/src/test/java/seedu/address/model/contact/IdTest.java
+++ b/src/test/java/seedu/address/model/contact/IdTest.java
@@ -1,0 +1,61 @@
+package seedu.address.model.contact;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class IdTest {
+
+    private static final String RANDOM_ID_REGEX = "i-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+
+    @Test
+    public void constructor_noArguments_randomId() {
+        assertTrue(new Id().value.matches(RANDOM_ID_REGEX));
+    }
+
+    @Test
+    public void constructor_inputValue_usesValueAsId() {
+        assertEquals("abcde_ABCDE-123", new Id("abcde_ABCDE-123").value);
+    }
+
+    @Test
+    public void synthesizeFrom_inputValue_expectedFormat() {
+        // Eq: All letters auto-lowercased
+        String value = "John Smith";
+        String regex = "john-smith-[0-9a-f]{6}";
+
+        assertTrue(Id.synthesizeFrom(value).value.matches(regex));
+
+        // Eq: Format non-standard chars to "x"
+        value = " Non-std@CHARACTERS résumé?";
+        regex = "non-stdxcharacters-rxsumxx-[0-9a-f]{6}";
+
+        assertTrue(Id.synthesizeFrom(value).value.matches(regex));
+
+        // Eq: Strip repeated dashes and spaces with single "-"
+        value = "a123- numbers --456_7890- ";
+        regex = "a123-numbers-456_7890-[0-9a-f]{6}";
+
+        assertTrue(Id.synthesizeFrom(value).value.matches(regex));
+
+        // Eq: Require leading letters
+        value = "1á2b3c";
+        regex = "i-1x2b3c-[0-9a-f]{6}";
+
+        assertTrue(Id.synthesizeFrom(value).value.matches(regex));
+
+        // Combined tests
+        value = "  123-- abc*def _--___-456áà?7890**ABC-  ";
+        regex = "i-123-abcxdef-456xxx7890xxabc-[0-9a-f]{6}";
+        assertTrue(Id.synthesizeFrom(value).value.matches(regex));
+    }
+
+    @Test
+    public void synthesizeFrom_blankValue_randomId() {
+        assertTrue(Id.synthesizeFrom("").value.matches(RANDOM_ID_REGEX));
+        assertTrue(Id.synthesizeFrom("  ").value.matches(RANDOM_ID_REGEX));
+        assertTrue(Id.synthesizeFrom(null).value.matches(RANDOM_ID_REGEX));
+    }
+
+}


### PR DESCRIPTION
Instead of a UUID, we synthesize IDs based on their names if none is provided.

For example: `"Company ABC"` may have a generated ID of `company-abc-a39cd5`.

This improves user-friendliness of the ID values.

We would need to input beyond 4.8k contacts of the same name for this to have a chance of collision of above 50% (birthday problem). Since our NFRs likely won't ever involve that many contacts (let alone having the same name), it should be alright.