### PR TITLE
Add support for "undoing" autocompleted terms

### DIFF
--- a/src/main/java/seedu/address/ui/AutocompleteTextField.java
+++ b/src/main/java/seedu/address/ui/AutocompleteTextField.java
@@ -2,8 +2,10 @@ package seedu.address.ui;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Stack;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javafx.geometry.Side;
@@ -16,11 +18,26 @@ import javafx.scene.control.TextField;
  * A text field capable of displaying autocomplete details.
  *
  * <p>
- * With reference to a proof-of-concept implementation from:
+ * Inspired by a proof-of-concept implementation from:
  * <a href="https://gist.github.com/floralvikings/10290131">floralvikings/AutoCompleteTextBox.java</a>
  * </p>
  */
 public class AutocompleteTextField extends TextField {
+
+    protected class TextChangeSnapshot {
+        public final String oldValue;
+        public final String newValue;
+
+        public TextChangeSnapshot(String oldValue, String newValue) {
+            this.oldValue = oldValue;
+            this.newValue = newValue;
+        }
+
+        @Override
+        public String toString() {
+            return "TextChangeSnapshot{'" + oldValue + '\'' + " to '" + newValue + "'}";
+        }
+    }
 
     /**
      * A functional interface that performs auto-completions based on the given partial inputs.
@@ -30,17 +47,26 @@ public class AutocompleteTextField extends TextField {
 
     private final ContextMenu autocompletePopup;
 
+    // Configuration variables
     private CompletionGenerator completionGenerator = s -> Stream.empty();
     private int popupLimit = 10;
+
+    // History tracking for autocomplete undo operations
+    private final Stack<TextChangeSnapshot> autocompleteHistory = new Stack<>();
 
     /**
      * Constructs a new text field with the ability to perform autocompletion.
      */
     public AutocompleteTextField() {
         super();
-        autocompletePopup = new ContextMenu();
-        textProperty().addListener(e -> updatePopupState());
-        focusedProperty().addListener(e -> autocompletePopup.hide());
+        this.autocompletePopup = new ContextMenu();
+
+        // Setup autocompletion popup menu UI updates
+        this.textProperty().addListener(e -> updatePopupState());
+        this.focusedProperty().addListener(e -> updatePopupState());
+
+        // Setup autocompletion undo data cleanup
+        this.textProperty().addListener((e, oldValue, newValue) -> updateUndoHistoryState(oldValue, newValue));
     }
 
     /**
@@ -65,18 +91,69 @@ public class AutocompleteTextField extends TextField {
      * @return true if an autocompleted result has been filled in, false otherwise.
      */
     public boolean triggerImmediateAutocompletion() {
-        var results = completionGenerator.apply(getText()).limit(2).collect(Collectors.toList());
-        if (results.size() < 1) {
+        Optional<String> firstSuggestion = completionGenerator.apply(getText())
+                .limit(1)
+                .findFirst();
+
+        firstSuggestion.ifPresent(this::triggerImmediateAutocompletionUsingResult);
+
+        return firstSuggestion.isPresent();
+    }
+
+    /**
+     * Triggers autocompletion immediately using the given result.
+     */
+    private void triggerImmediateAutocompletionUsingResult(String result) {
+        String oldText = this.getText();
+
+        // Add data for undoing if there's a change
+        if (!Objects.equals(oldText, result)) {
+            autocompleteHistory.add(new TextChangeSnapshot(oldText, result));
+        }
+
+        // Update the text field
+        this.setText(result + " "); // add a new space character to allow for faster continuation
+
+        // Update the view and cursor location
+        this.requestFocus();
+        this.end();
+        this.updatePopupState();
+    }
+
+    /**
+     * Undoes the last immediate autocompleted result.
+     * This only does something when invoked at a stage where the text is the previously autocompleted result.
+     */
+    public boolean undoLastImmediateAutocompletion() {
+        if (autocompleteHistory.isEmpty()) {
             return false;
         }
 
-        String result = results.get(0);
-        setText(result + " ");
-        requestFocus();
-        end();
-        updatePopupState();
+        TextChangeSnapshot snapshot = autocompleteHistory.peek();
 
+        // Verify that the current text is correctly at the latest snapshot
+        if (!this.getText().trim().equals(snapshot.newValue)) {
+            return false;
+        }
+
+        // Pop the result
+        autocompleteHistory.pop();
+
+        // Set the old value back in
+        this.setText(snapshot.oldValue + " "); // preserve the extra space previously added
+
+        // Update the view and cursor location
+        this.requestFocus();
+        this.end();
+        this.updatePopupState();
         return true;
+    }
+
+    /**
+     * Returns true if the autocomplete popup menu is visible, false otherwise.
+     */
+    public boolean isPopupVisible() {
+        return this.autocompletePopup.isShowing();
     }
 
     /**
@@ -96,12 +173,7 @@ public class AutocompleteTextField extends TextField {
                 .forEachOrdered(autocompletedString -> {
                     Label entryLabel = new Label(autocompletedString);
                     CustomMenuItem item = new CustomMenuItem(entryLabel, false);
-                    item.setOnAction(e -> {
-                        setText(autocompletedString + " ");
-                        requestFocus();
-                        end();
-                        updatePopupState();
-                    });
+                    item.setOnAction(e -> triggerImmediateAutocompletionUsingResult(autocompletedString));
                     menuItems.add(item);
                 });
 
@@ -116,4 +188,27 @@ public class AutocompleteTextField extends TextField {
             autocompletePopup.hide();
         }
     }
+
+    /**
+     * Update undo history tracked state based on the change for text field old values to new values.
+     */
+    protected void updateUndoHistoryState(String previousValue, String currentValue) {
+        if (autocompleteHistory.isEmpty()) {
+            return;
+        }
+
+        // Heuristic for clearing history:
+        //   IF current value is no longer a prefix of the latest autocomplete result OR is of the undone state
+        //   THEN said autocompletion snapshot is no longer applicable.
+
+        while (!currentValue.startsWith(autocompleteHistory.peek().newValue)
+                || currentValue.trim().equals(autocompleteHistory.peek().oldValue)) {
+
+            autocompleteHistory.pop();
+            if (autocompleteHistory.isEmpty()) {
+                break;
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
This PR adds support for undoing any autocompleted result using **BACKSPACE**.


### Example Usage

  1. Suppose a user has typed: "`add --org -n|`" where `|` refers to the text cursor.

  2. Pressing **SPACE** could yield: "`add --org --name |`".

  3. The user may then revert the autocompletion with **BACKSPACE**, of which would yield "`add --org -n |`".

With step 3, it allows a user to indicate their intent to keep `-n` (as typed in step 1), while adding a ` ` character after that (as intended by the original **SPACE** keystroke in step 2).

More concretely, this allows for users to type inputs such as `--desc Requires 2 - 5 years experience` (notice the spaces between the dash), which would have been near impossible without a way to undo autocompletion.


### Additional Notes

This undo implementation involves tracking the _full autocomplete history_ so far for a user input. That means all autocompletions are remembered unless the history is tampered (e.g., by modifying a command in the middle instead of the end).

As an example, this is a possible flow (where `|` is the text cursor) thanks to full historical tracking:

  1. User types in keyboard, character by character, as follows: `add -r -n Amy -ph 12|`

  2. Remember that every **SPACE** keystroke invokes autocomplete.
    Hence, the command box now shows: `add --rec --name Amy --phone 12|`

  3. The user begins pressing **BACKSPACE** repeatedly. The command box is updated as follows:

  - `add --rec --name Amy --phone 1|`
  - `add --rec --name Amy --phone |`
  - `add --rec --name Amy -ph |` (reverted `--phone ` to `-ph `)
  - `add --rec --name Amy -ph|`
  - `add --rec --name Amy -p|`
  - `add --rec --name Amy -|`
  - `add --rec --name Amy |`
  - `add --rec --name Amy|`
  - `add --rec --name Am|`
  - `add --rec --name A|`
  - `add --rec --name |`
  - `add --rec -n |` (reverted `--name ` to `-n `)
  - `add --rec -n|`
  - `add --rec -|`
  - etc.

