### PR TITLE
Fix link between `Organization` and `Recruiter`

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -108,6 +108,9 @@ public class Messages {
         return builder.toString();
     }
 
+    /**
+     * Formats the given {@code childrenContacts} for display to the user.
+     */
     public static String formatChildren(List<Contact> childrenContacts) {
         return childrenContacts.stream()
                 .map(c -> Messages.format(c) + "\n")

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -1,5 +1,6 @@
 package seedu.address.logic;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -105,6 +106,13 @@ public class Messages {
                 .append("; Tags: ");
         contact.getTags().forEach(builder::append);
         return builder.toString();
+    }
+
+    public static String formatChildren(List<Contact> childrenContacts) {
+        return childrenContacts.stream()
+                .map(c -> Messages.format(c) + "\n")
+                .reduce((c1, c2) -> c1 + c2)
+                .orElse("No other contacts found");
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -177,7 +177,7 @@ public class AddCommand extends Command {
     }
 
     protected Contact createContact() {
-        return new Contact(name, id, phone, email, url, address, tags);
+        return new Contact(name, id, phone, email, url, address, tags, null);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -65,7 +65,7 @@ public class DeleteCommand extends Command {
 
     private final Function<Model, Contact> contactFunction;
 
-    private final CommandException commandException;
+    protected final CommandException commandException;
 
     /**
      * @param targetIndex of the contact to be deleted

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -61,11 +61,11 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_DELETE_CONTACT_SUCCESS = "Deleted Contact: %1$s";
 
+    protected final CommandException commandException;
+
     private final Object selector; // TODO: This is very sus but this will only be used for equals comparison
 
     private final Function<Model, Contact> contactFunction;
-
-    protected final CommandException commandException;
 
     /**
      * @param targetIndex of the contact to be deleted

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -16,6 +16,8 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.Id;
+import seedu.address.model.contact.Recruiter;
+import seedu.address.model.contact.Type;
 
 /**
  * Deletes a contact identified using its displayed index or its contact id from the address book.
@@ -45,6 +47,7 @@ public class DeleteCommand extends Command {
         });
     });
 
+    public static final String MESSAGE_ILLEGAL_DELETE = "Contacts of type %s cannot have links to a parent contact.";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the contact identified by the index number used in the displayed contact list.\n"
@@ -128,7 +131,29 @@ public class DeleteCommand extends Command {
             throw commandException;
         }
         model.deleteContact(contactToDelete);
+        handleChildren(model, contactToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_CONTACT_SUCCESS, Messages.format(contactToDelete)));
+    }
+
+    protected void handleChildren(Model model, Contact contactToDelete) throws CommandException {
+        requireNonNull(model);
+        // At this point if the contact is null, the superclass would have thrown exception.
+        // Superclass would have also deleted the contact from the list.
+        assert contactToDelete != null;
+        List<Contact> childrenContacts = contactToDelete.getChildren(model);
+        for (Contact child : childrenContacts) {
+            // Enforce that only recruiters can have links to parent organizations.
+            if (child.getType() != Type.RECRUITER) {
+                throw new CommandException(String.format(MESSAGE_ILLEGAL_DELETE, child.getType().toString()));
+            }
+            // Create a new recruiter with no link to the deleted organization.
+            Recruiter newRecruiter = new Recruiter(
+                    child.getName(), child.getId(), child.getPhone().orElse(null),
+                    child.getEmail().orElse(null), child.getUrl().orElse(null),
+                    child.getAddress().orElse(null), child.getTags(), null
+            );
+            model.setContact(child, newRecruiter);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteWithChildrenCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteWithChildrenCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Arrays;
+import java.util.List;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
@@ -40,14 +41,12 @@ public class DeleteWithChildrenCommand extends DeleteCommand {
         // At this point if the contact is null, the superclass would have thrown exception.
         // Superclass would have also deleted the contact from the list.
         assert contactToDelete != null;
-        Contact[] childContacts = contactToDelete.getChildren();
-        Arrays.stream(childContacts).forEach(contact -> {
-            model.deleteContact(contactToDelete);
-        });
+        List<Contact> childContacts = contactToDelete.getChildren(model);
+        childContacts.forEach(model::deleteContact);
         return new CommandResult(String.format(
                 MESSAGE_DELETE_CONTACT_SUCCESS,
                 Messages.format(contactToDelete),
-                Arrays.stream(childContacts)
+                childContacts.stream()
                         .map(c -> Messages.format(c) + "\n")
                         .reduce((c1, c2) -> c1 + c2)
                         .orElse("No other contacts found") // I can't find a better method.

--- a/src/main/java/seedu/address/logic/commands/DeleteWithChildrenCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteWithChildrenCommand.java
@@ -36,15 +36,12 @@ public class DeleteWithChildrenCommand extends DeleteCommand {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         Contact contactToDelete = super.getContact(model);
-        List<Contact> childContacts = contactToDelete.getChildren(model);
+        List<Contact> childrenContacts = contactToDelete.getChildren(model);
         super.execute(model);
         return new CommandResult(String.format(
                 MESSAGE_DELETE_CONTACT_SUCCESS,
                 Messages.format(contactToDelete),
-                childContacts.stream()
-                        .map(c -> Messages.format(c) + "\n")
-                        .reduce((c1, c2) -> c1 + c2)
-                        .orElse("No other contacts found") // I can't find a better method.
+                Messages.formatChildren(childrenContacts)
         ));
     }
 
@@ -53,7 +50,7 @@ public class DeleteWithChildrenCommand extends DeleteCommand {
         // At this point if the contact is null, the superclass would have thrown exception.
         // Superclass would have also deleted the contact from the list.
         assert contactToDelete != null;
-        List<Contact> childContacts = contactToDelete.getChildren(model);
-        childContacts.forEach(model::deleteContact);
+        List<Contact> childrenContacts = contactToDelete.getChildren(model);
+        childrenContacts.forEach(model::deleteContact);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteWithChildrenCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteWithChildrenCommand.java
@@ -36,6 +36,9 @@ public class DeleteWithChildrenCommand extends DeleteCommand {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         Contact contactToDelete = super.getContact(model);
+        if (contactToDelete == null) {
+            throw commandException;
+        }
         List<Contact> childrenContacts = contactToDelete.getChildren(model);
         super.execute(model);
         return new CommandResult(String.format(

--- a/src/main/java/seedu/address/logic/commands/DeleteWithChildrenCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteWithChildrenCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Arrays;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
@@ -37,12 +36,8 @@ public class DeleteWithChildrenCommand extends DeleteCommand {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         Contact contactToDelete = super.getContact(model);
-        super.execute(model);
-        // At this point if the contact is null, the superclass would have thrown exception.
-        // Superclass would have also deleted the contact from the list.
-        assert contactToDelete != null;
         List<Contact> childContacts = contactToDelete.getChildren(model);
-        childContacts.forEach(model::deleteContact);
+        super.execute(model);
         return new CommandResult(String.format(
                 MESSAGE_DELETE_CONTACT_SUCCESS,
                 Messages.format(contactToDelete),
@@ -51,5 +46,14 @@ public class DeleteWithChildrenCommand extends DeleteCommand {
                         .reduce((c1, c2) -> c1 + c2)
                         .orElse("No other contacts found") // I can't find a better method.
         ));
+    }
+
+    @Override
+    protected void handleChildren(Model model, Contact contactToDelete) {
+        // At this point if the contact is null, the superclass would have thrown exception.
+        // Superclass would have also deleted the contact from the list.
+        assert contactToDelete != null;
+        List<Contact> childContacts = contactToDelete.getChildren(model);
+        childContacts.forEach(model::deleteContact);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -182,10 +182,6 @@ public class EditCommand extends Command {
         return new CommandResult(String.format(MESSAGE_EDIT_CONTACT_SUCCESS, Messages.format(editedContact)));
     }
 
-
-
-
-
     /**
      * Creates and returns a {@code Contact} with the details of {@code contactToEdit}
      * edited with {@code editContactDescriptor}.
@@ -209,15 +205,31 @@ public class EditCommand extends Command {
         Set<Tag> updatedTags = editContactDescriptor.getTags()
             .orElse(contactToEdit.getTags());
 
-
+        // TODO: Refactor into two methods to handle the two cases.
         if (contactToEdit.getType() == Type.ORGANIZATION) {
             Status updatedStatus = editContactDescriptor.getStatus()
                     .orElse(((Organization) contactToEdit).getStatus().orElse(null));
 
             Position updatedPosition = editContactDescriptor.getPosition()
                     .orElse(((Organization) contactToEdit).getPosition().orElse(null));
-            return new Organization(updatedName, updatedId, updatedPhone, updatedEmail, updatedUrl,
-                    updatedAddress, updatedTags, updatedStatus, updatedPosition, null);
+
+            Organization updatedOrganization = new Organization(updatedName, updatedId, updatedPhone, updatedEmail,
+                    updatedUrl, updatedAddress, updatedTags, updatedStatus, updatedPosition, null);
+
+            // Updates all recruiters linked to the old organization to link to the updated one.
+            List<Contact> childrenContacts = contactToEdit.getChildren(model);
+            for (Contact child : childrenContacts) {
+                assert child.getType() == Type.RECRUITER;
+                Recruiter updatedRecruiter = new Recruiter(
+                        child.getName(), child.getId(), child.getPhone().orElse(null),
+                        child.getEmail().orElse(null), child.getUrl().orElse(null),
+                        child.getAddress().orElse(null), child.getTags(), updatedOrganization
+                );
+                model.setContact(child, updatedRecruiter);
+            }
+
+            return updatedOrganization;
+
         } else if (contactToEdit.getType() == Type.RECRUITER) {
             Optional<Id> updatedOid = editContactDescriptor
                     .getOrganizationId()

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -235,7 +235,8 @@ public class EditCommand extends Command {
                     updatedAddress, updatedTags, updatedOrganization);
         }
 
-        return new Contact(updatedName, updatedId, updatedPhone, updatedEmail, updatedUrl, updatedAddress, updatedTags);
+        return new Contact(updatedName, updatedId, updatedPhone, updatedEmail, updatedUrl, updatedAddress,
+                updatedTags, null);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/contact/Contact.java
+++ b/src/main/java/seedu/address/model/contact/Contact.java
@@ -31,12 +31,15 @@ public class Contact {
     private final Optional<Address> address;
     private final Set<Tag> tags = new HashSet<>();
 
+    private Optional<Contact> parent;
+
     /**
      * Name and id fields must be non-null.
      * Tags must be non-null but can be empty as well.
      * The other fields can be null.
      */
-    public Contact(Name name, Id id, Phone phone, Email email, Url url, Address address, Set<Tag> tags) {
+    public Contact(Name name, Id id, Phone phone, Email email, Url url, Address address, Set<Tag> tags,
+                   Contact parent) {
         requireAllNonNull(name, id, tags);
         this.name = name;
         this.id = id;
@@ -45,6 +48,7 @@ public class Contact {
         this.url = Optional.ofNullable(url);
         this.address = Optional.ofNullable(address);
         this.tags.addAll(tags);
+        this.parent = Optional.ofNullable(parent);
     }
 
     public Type getType() {
@@ -95,6 +99,13 @@ public class Contact {
 
         return otherContact != null
                 && otherContact.getId().equals(getId());
+    }
+
+    /**
+     * Gives the parent of this contact.
+     */
+    public Optional<Contact> getParent() {
+        return parent;
     }
 
     /**

--- a/src/main/java/seedu/address/model/contact/Contact.java
+++ b/src/main/java/seedu/address/model/contact/Contact.java
@@ -115,9 +115,7 @@ public class Contact {
         // TODO add to DG
         return model.getAddressBook().getContactList().stream()
                 .filter(contact -> contact.getParent()
-                        .map(parent -> {
-                            return parent.equals(this);
-                        })
+                        .map(parent -> parent.equals(this))
                         .orElse(false))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/seedu/address/model/contact/Contact.java
+++ b/src/main/java/seedu/address/model/contact/Contact.java
@@ -4,12 +4,14 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-import seedu.address.commons.exceptions.IllegalOperationException;
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.Model;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -17,8 +19,6 @@ import seedu.address.model.tag.Tag;
  * Guarantees: name and id are present and not null, field values are immutable and if present, are validated.
  */
 public class Contact {
-
-    private static final String ILLEGAL_OPERATION_MESSAGE = "Contact cannot have child contacts";
 
     // Identity fields
     private final Name name;
@@ -31,7 +31,7 @@ public class Contact {
     private final Optional<Address> address;
     private final Set<Tag> tags = new HashSet<>();
 
-    private Optional<Contact> parent;
+    private final Optional<Contact> parent;
 
     /**
      * Name and id fields must be non-null.
@@ -111,20 +111,15 @@ public class Contact {
     /**
      * Gives the array of contacts that are linked under this contact.
      */
-    public Contact[] getChildren() {
-        // default return value
+    public List<Contact> getChildren(Model model) {
         // TODO add to DG
-        return new Contact[]{};
-    }
-
-    /**
-     * Adds a child contact under this contact.
-     * @throws IllegalOperationException if this contact cannot accept child contacts
-     */
-    public void addChild(Contact childContact) throws IllegalOperationException {
-        // Should throw exception if the type of contact cannot have child contacts.
-        // TODO add to DG, do JavaDocs
-        throw new IllegalOperationException(ILLEGAL_OPERATION_MESSAGE);
+        return model.getAddressBook().getContactList().stream()
+                .filter(contact -> contact.getParent()
+                        .map(parent -> {
+                            return parent.equals(this);
+                        })
+                        .orElse(false))
+                .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/seedu/address/model/contact/Organization.java
+++ b/src/main/java/seedu/address/model/contact/Organization.java
@@ -38,7 +38,7 @@ public class Organization extends Contact {
             Address address, Set<Tag> tags, Status status, Position position,
             Set<Id> rids
     ) {
-        super(name, id, phone, email, url, address, tags);
+        super(name, id, phone, email, url, address, tags, null);
         this.status = Optional.ofNullable(status);
         this.position = Optional.ofNullable(position);
         // Todo: Likely to deprecate rids completely

--- a/src/main/java/seedu/address/model/contact/Recruiter.java
+++ b/src/main/java/seedu/address/model/contact/Recruiter.java
@@ -19,8 +19,6 @@ public class Recruiter extends Contact {
                     + "the linked organization should be present in the address book "
                     + "and have a valid id";
 
-    private final Optional<Organization> organization;
-
     /**
      * Name and id fields must be non-null.
      * Tags must be non-null but can be empty as well.
@@ -28,24 +26,23 @@ public class Recruiter extends Contact {
      */
     public Recruiter(Name name, Id id, Phone phone, Email email, Url url, Address address, Set<Tag> tags,
                      Organization organization) {
-        super(name, id, phone, email, url, address, tags);
-        this.organization = Optional.ofNullable(organization);
+        super(name, id, phone, email, url, address, tags, organization);
     }
 
     public Optional<Id> getOrganizationId() {
-        return organization.map(Contact::getId);
+        return getOrganization().map(Contact::getId);
     }
 
     public Optional<Organization> getOrganization() {
-        return organization;
+        return super.getParent().map(contact -> (Organization) contact);
     }
 
     public boolean isLinkedToOrganization(Organization otherOrg) {
-        return organization.map(org -> org.equals(otherOrg)).orElse(false);
+        return getOrganization().map(org -> org.equals(otherOrg)).orElse(false);
     }
 
     public boolean isLinkedToOrganization(Id organizationId) {
-        return organization.map(org -> org.getId().equals(organizationId)).orElse(false);
+        return getOrganization().map(org -> org.getId().equals(organizationId)).orElse(false);
     }
 
     @Override
@@ -73,19 +70,19 @@ public class Recruiter extends Contact {
                 && getAddress().equals(otherContact.getAddress())
                 && getUrl().equals(otherContact.getUrl())
                 && getTags().equals(otherContact.getTags())
-                && organization.equals(otherContact.organization);
+                && getOrganization().equals(otherContact.getOrganization());
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(
-                getId(), getType(), getName(), getPhone(), getEmail(), getAddress(), getTags(), organization
+                getId(), getType(), getName(), getPhone(), getEmail(), getAddress(), getTags(), getOrganization()
         );
     }
 
     @Override
     public ToStringBuilder toStringBuilder() {
         return super.toStringBuilder()
-                .add("organization", organization);
+                .add("organization", getOrganization());
     }
 }

--- a/src/main/java/seedu/address/model/contact/Recruiter.java
+++ b/src/main/java/seedu/address/model/contact/Recruiter.java
@@ -37,14 +37,6 @@ public class Recruiter extends Contact {
         return super.getParent().map(contact -> (Organization) contact);
     }
 
-    public boolean isLinkedToOrganization(Organization otherOrg) {
-        return getOrganization().map(org -> org.equals(otherOrg)).orElse(false);
-    }
-
-    public boolean isLinkedToOrganization(Id organizationId) {
-        return getOrganization().map(org -> org.getId().equals(organizationId)).orElse(false);
-    }
-
     @Override
     public Type getType() {
         return Type.RECRUITER;

--- a/src/main/java/seedu/address/storage/JsonAdaptedContact.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedContact.java
@@ -200,7 +200,8 @@ class JsonAdaptedContact {
             );
         }
         default:
-            return new Contact(modelName, modelId, modelPhone, modelEmail, modelUrl, modelAddress, modelTags);
+            return new Contact(modelName, modelId, modelPhone, modelEmail, modelUrl, modelAddress,
+                    modelTags, null);
         }
     }
 

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -77,7 +77,7 @@
     "email" : "rexlee@smu.edu.sg",
     "url": "www.rex.com",
     "address" : "80 Stamford Rd",
-    "oid": "smu-is_sg",
+    "oid": "ntu-soc_sg",
     "tags" : [ "cool", "resourceful" ]
   }, {
     "name" : "Richard Lim",
@@ -87,7 +87,7 @@
     "email" : "richlee@smu.edu.sg",
     "url": "www.richard_lion_heart.com",
     "address" : "80 Stamford Rd",
-    "oid": "smu-is_sg",
+    "oid": null,
     "tags" : [ ]
   } ]
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -11,7 +11,6 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CONTACT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_LINKED_ORGANIZATION;
 import static seedu.address.testutil.TypicalIndexes.INDEX_LINKED_RECRUITER;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_CONTACT;
-import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_CONTACT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_UNLINKED_ORGANIZATION;
 import static seedu.address.testutil.TypicalIndexes.INDEX_UNLINKED_RECRUITER;
 
@@ -37,7 +36,7 @@ public class DeleteCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
-    public void execute_validIndexUnfilteredList_unlinkedOrganization_success() {
+    public void execute_validIndexUnfilteredList_unlinkedOrganizationSuccess() {
         Contact contactToDelete = model.getFilteredContactList()
                 .get(INDEX_UNLINKED_ORGANIZATION.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_UNLINKED_ORGANIZATION);
@@ -52,7 +51,7 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_validIndexUnfilteredList_unlinkedRecruiter_success() {
+    public void execute_validIndexUnfilteredList_unlinkedRecruiterSuccess() {
         Contact contactToDelete = model.getFilteredContactList()
                 .get(INDEX_UNLINKED_RECRUITER.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_UNLINKED_RECRUITER);
@@ -67,7 +66,7 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_validIndexUnfilteredList_linkedOrganization_success() {
+    public void execute_validIndexUnfilteredList_linkedOrganizationSuccess() {
         Contact contactToDelete = model.getFilteredContactList()
                 .get(INDEX_LINKED_ORGANIZATION.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_LINKED_ORGANIZATION);
@@ -89,7 +88,7 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_validIndexUnfilteredList_linkedRecruiter_success() {
+    public void execute_validIndexUnfilteredList_linkedRecruiterSuccess() {
         Contact contactToDelete = model.getFilteredContactList()
                 .get(INDEX_LINKED_RECRUITER.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_LINKED_RECRUITER);
@@ -133,7 +132,7 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_validIndexFilteredList_unlinkedOrganization_success() {
+    public void execute_validIndexFilteredList_unlinkedOrganizationSuccess() {
         showContactAtIndex(model, INDEX_UNLINKED_ORGANIZATION);
 
         Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
@@ -150,7 +149,7 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_validIndexFilteredList_unlinkedRecruiter_success() {
+    public void execute_validIndexFilteredList_unlinkedRecruiterSuccess() {
         showContactAtIndex(model, INDEX_UNLINKED_RECRUITER);
 
         Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
@@ -167,7 +166,7 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_validIndexFilteredList_linkedOrganization_success() {
+    public void execute_validIndexFilteredList_linkedOrganizationSuccess() {
         showContactAtIndex(model, INDEX_LINKED_ORGANIZATION);
 
         Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
@@ -191,7 +190,7 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_validIndexFilteredList_linkedRecruiter_success() {
+    public void execute_validIndexFilteredList_linkedRecruiterSuccess() {
         showContactAtIndex(model, INDEX_LINKED_RECRUITER);
 
         Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -8,7 +8,14 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showContactAtIndex;
 import static seedu.address.testutil.TypicalContacts.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CONTACT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_LINKED_ORGANIZATION;
+import static seedu.address.testutil.TypicalIndexes.INDEX_LINKED_RECRUITER;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_CONTACT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_CONTACT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_UNLINKED_ORGANIZATION;
+import static seedu.address.testutil.TypicalIndexes.INDEX_UNLINKED_RECRUITER;
+
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -18,6 +25,8 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.contact.Contact;
+import seedu.address.model.contact.Recruiter;
+import seedu.address.testutil.RecruiterBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
@@ -28,9 +37,10 @@ public class DeleteCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
-    public void execute_validIndexUnfilteredList_success() {
-        Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_CONTACT);
+    public void execute_validIndexUnfilteredList_unlinkedOrganization_success() {
+        Contact contactToDelete = model.getFilteredContactList()
+                .get(INDEX_UNLINKED_ORGANIZATION.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_UNLINKED_ORGANIZATION);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
                 Messages.format(contactToDelete));
@@ -38,6 +48,62 @@ public class DeleteCommandTest {
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deleteContact(contactToDelete);
 
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexUnfilteredList_unlinkedRecruiter_success() {
+        Contact contactToDelete = model.getFilteredContactList()
+                .get(INDEX_UNLINKED_RECRUITER.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_UNLINKED_RECRUITER);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
+                Messages.format(contactToDelete));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteContact(contactToDelete);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexUnfilteredList_linkedOrganization_success() {
+        Contact contactToDelete = model.getFilteredContactList()
+                .get(INDEX_LINKED_ORGANIZATION.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_LINKED_ORGANIZATION);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
+                Messages.format(contactToDelete));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteContact(contactToDelete);
+        List<Contact> childrenContacts = contactToDelete.getChildren(expectedModel);
+        for (Contact child : childrenContacts) {
+            expectedModel.setContact(child,
+                    new RecruiterBuilder((Recruiter) child)
+                            .withOrganization(null)
+                            .build());
+        }
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexUnfilteredList_linkedRecruiter_success() {
+        Contact contactToDelete = model.getFilteredContactList()
+                .get(INDEX_LINKED_RECRUITER.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_LINKED_RECRUITER);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
+                Messages.format(contactToDelete));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteContact(contactToDelete);
+        Contact parent = contactToDelete.getParent().orElse(null);
+        assert parent != null;
+        List<Contact> childrenContacts = parent.getChildren(expectedModel);
+
+        assertFalse(childrenContacts.contains(contactToDelete));
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
 
@@ -63,6 +129,85 @@ public class DeleteCommandTest {
         expectedModel.deleteContact(contactToDelete);
         showNoContact(expectedModel);
 
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_unlinkedOrganization_success() {
+        showContactAtIndex(model, INDEX_UNLINKED_ORGANIZATION);
+
+        Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_CONTACT);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
+                Messages.format(contactToDelete));
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteContact(contactToDelete);
+        showNoContact(expectedModel);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_unlinkedRecruiter_success() {
+        showContactAtIndex(model, INDEX_UNLINKED_RECRUITER);
+
+        Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_CONTACT);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
+                Messages.format(contactToDelete));
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteContact(contactToDelete);
+        showNoContact(expectedModel);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_linkedOrganization_success() {
+        showContactAtIndex(model, INDEX_LINKED_ORGANIZATION);
+
+        Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_CONTACT);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
+                Messages.format(contactToDelete));
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteContact(contactToDelete);
+        showNoContact(expectedModel);
+        List<Contact> childrenContacts = contactToDelete.getChildren(expectedModel);
+        for (Contact child : childrenContacts) {
+            expectedModel.setContact(child,
+                    new RecruiterBuilder((Recruiter) child)
+                            .withOrganization(null)
+                            .build());
+        }
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_linkedRecruiter_success() {
+        showContactAtIndex(model, INDEX_LINKED_RECRUITER);
+
+        Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_CONTACT);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
+                Messages.format(contactToDelete));
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteContact(contactToDelete);
+        showNoContact(expectedModel);
+        Contact parent = contactToDelete.getParent().orElse(null);
+        assert parent != null;
+        List<Contact> childrenContacts = parent.getChildren(expectedModel);
+
+        assertFalse(childrenContacts.contains(contactToDelete));
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -37,7 +37,7 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_unlinkedOrganizationSuccess() {
-        Contact contactToDelete = model.getFilteredContactList()
+        Contact contactToDelete = model.getDisplayedContactList()
                 .get(INDEX_UNLINKED_ORGANIZATION.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_UNLINKED_ORGANIZATION);
 
@@ -52,7 +52,7 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_unlinkedRecruiterSuccess() {
-        Contact contactToDelete = model.getFilteredContactList()
+        Contact contactToDelete = model.getDisplayedContactList()
                 .get(INDEX_UNLINKED_RECRUITER.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_UNLINKED_RECRUITER);
 
@@ -67,7 +67,7 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_linkedOrganizationSuccess() {
-        Contact contactToDelete = model.getFilteredContactList()
+        Contact contactToDelete = model.getDisplayedContactList()
                 .get(INDEX_LINKED_ORGANIZATION.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_LINKED_ORGANIZATION);
 
@@ -89,7 +89,7 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_linkedRecruiterSuccess() {
-        Contact contactToDelete = model.getFilteredContactList()
+        Contact contactToDelete = model.getDisplayedContactList()
                 .get(INDEX_LINKED_RECRUITER.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_LINKED_RECRUITER);
 
@@ -135,7 +135,7 @@ public class DeleteCommandTest {
     public void execute_validIndexFilteredList_unlinkedOrganizationSuccess() {
         showContactAtIndex(model, INDEX_UNLINKED_ORGANIZATION);
 
-        Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        Contact contactToDelete = model.getDisplayedContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_CONTACT);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
@@ -152,7 +152,7 @@ public class DeleteCommandTest {
     public void execute_validIndexFilteredList_unlinkedRecruiterSuccess() {
         showContactAtIndex(model, INDEX_UNLINKED_RECRUITER);
 
-        Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        Contact contactToDelete = model.getDisplayedContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_CONTACT);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
@@ -169,7 +169,7 @@ public class DeleteCommandTest {
     public void execute_validIndexFilteredList_linkedOrganizationSuccess() {
         showContactAtIndex(model, INDEX_LINKED_ORGANIZATION);
 
-        Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        Contact contactToDelete = model.getDisplayedContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_CONTACT);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
@@ -193,7 +193,7 @@ public class DeleteCommandTest {
     public void execute_validIndexFilteredList_linkedRecruiterSuccess() {
         showContactAtIndex(model, INDEX_LINKED_RECRUITER);
 
-        Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        Contact contactToDelete = model.getDisplayedContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_CONTACT);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_CONTACT_SUCCESS,

--- a/src/test/java/seedu/address/logic/commands/DeleteWithChildrenCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteWithChildrenCommandTest.java
@@ -1,0 +1,265 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showContactAtIndex;
+import static seedu.address.testutil.TypicalContacts.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CONTACT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_LINKED_ORGANIZATION;
+import static seedu.address.testutil.TypicalIndexes.INDEX_LINKED_RECRUITER;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_CONTACT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_UNLINKED_ORGANIZATION;
+import static seedu.address.testutil.TypicalIndexes.INDEX_UNLINKED_RECRUITER;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.contact.Contact;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code DeleteWithChildrenCommand}.
+ */
+public class DeleteWithChildrenCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_unlinkedOrganization_success() {
+        Contact contactToDelete = model.getFilteredContactList()
+                .get(INDEX_UNLINKED_ORGANIZATION.getZeroBased());
+        DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(INDEX_UNLINKED_ORGANIZATION);
+
+        String expectedMessage = String.format(DeleteWithChildrenCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
+                Messages.format(contactToDelete),
+                Messages.formatChildren(contactToDelete.getChildren(model)));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteContact(contactToDelete);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexUnfilteredList_unlinkedRecruiter_success() {
+        Contact contactToDelete = model.getFilteredContactList()
+                .get(INDEX_UNLINKED_RECRUITER.getZeroBased());
+        DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(INDEX_UNLINKED_RECRUITER);
+
+        String expectedMessage = String.format(DeleteWithChildrenCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
+                Messages.format(contactToDelete),
+                Messages.formatChildren(contactToDelete.getChildren(model)));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteContact(contactToDelete);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexUnfilteredList_linkedOrganization_success() {
+        Contact contactToDelete = model.getFilteredContactList()
+                .get(INDEX_LINKED_ORGANIZATION.getZeroBased());
+        DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(INDEX_LINKED_ORGANIZATION);
+
+        String expectedMessage = String.format(DeleteWithChildrenCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
+                Messages.format(contactToDelete),
+                Messages.formatChildren(contactToDelete.getChildren(model)));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteContact(contactToDelete);
+        List<Contact> childrenContacts = contactToDelete.getChildren(expectedModel);
+        for (Contact child : childrenContacts) {
+            expectedModel.deleteContact(child);
+        }
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexUnfilteredList_linkedRecruiter_success() {
+        Contact contactToDelete = model.getFilteredContactList()
+                .get(INDEX_LINKED_RECRUITER.getZeroBased());
+        DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(INDEX_LINKED_RECRUITER);
+
+        String expectedMessage = String.format(DeleteWithChildrenCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
+                Messages.format(contactToDelete),
+                Messages.formatChildren(contactToDelete.getChildren(model)));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteContact(contactToDelete);
+        Contact parent = contactToDelete.getParent().orElse(null);
+        assert parent != null;
+        List<Contact> childrenContacts = parent.getChildren(expectedModel);
+
+        assertFalse(childrenContacts.contains(contactToDelete));
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredContactList().size() + 1);
+        DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showContactAtIndex(model, INDEX_FIRST_CONTACT);
+
+        Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(INDEX_FIRST_CONTACT);
+
+        String expectedMessage = String.format(DeleteWithChildrenCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
+                Messages.format(contactToDelete),
+                Messages.formatChildren(contactToDelete.getChildren(model)));
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteContact(contactToDelete);
+        showNoContact(expectedModel);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_unlinkedOrganization_success() {
+        showContactAtIndex(model, INDEX_UNLINKED_ORGANIZATION);
+
+        Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(INDEX_FIRST_CONTACT);
+
+        String expectedMessage = String.format(DeleteWithChildrenCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
+                Messages.format(contactToDelete),
+                Messages.formatChildren(contactToDelete.getChildren(model)));
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteContact(contactToDelete);
+        showNoContact(expectedModel);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_unlinkedRecruiter_success() {
+        showContactAtIndex(model, INDEX_UNLINKED_RECRUITER);
+
+        Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(INDEX_FIRST_CONTACT);
+
+        String expectedMessage = String.format(DeleteWithChildrenCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
+                Messages.format(contactToDelete),
+                Messages.formatChildren(contactToDelete.getChildren(model)));
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteContact(contactToDelete);
+        showNoContact(expectedModel);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_linkedOrganization_success() {
+        showContactAtIndex(model, INDEX_LINKED_ORGANIZATION);
+
+        Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(INDEX_FIRST_CONTACT);
+
+        String expectedMessage = String.format(DeleteWithChildrenCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
+                Messages.format(contactToDelete),
+                Messages.formatChildren(contactToDelete.getChildren(model)));
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteContact(contactToDelete);
+        showNoContact(expectedModel);
+        List<Contact> childrenContacts = contactToDelete.getChildren(expectedModel);
+        for (Contact child : childrenContacts) {
+            expectedModel.deleteContact(child);
+        }
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_linkedRecruiter_success() {
+        showContactAtIndex(model, INDEX_LINKED_RECRUITER);
+
+        Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(INDEX_FIRST_CONTACT);
+
+        String expectedMessage = String.format(DeleteWithChildrenCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
+                Messages.format(contactToDelete),
+                Messages.formatChildren(contactToDelete.getChildren(model)));
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteContact(contactToDelete);
+        showNoContact(expectedModel);
+        Contact parent = contactToDelete.getParent().orElse(null);
+        assert parent != null;
+        List<Contact> childrenContacts = parent.getChildren(expectedModel);
+
+        assertFalse(childrenContacts.contains(contactToDelete));
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showContactAtIndex(model, INDEX_FIRST_CONTACT);
+
+        Index outOfBoundIndex = INDEX_SECOND_CONTACT;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getContactList().size());
+
+        DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        DeleteWithChildrenCommand deleteFirstCommand = new DeleteWithChildrenCommand(INDEX_FIRST_CONTACT);
+        DeleteWithChildrenCommand deleteSecondCommand = new DeleteWithChildrenCommand(INDEX_SECOND_CONTACT);
+
+        // same object -> returns true
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
+
+        // same values -> returns true
+        DeleteWithChildrenCommand deleteFirstCommandCopy = new DeleteWithChildrenCommand(INDEX_FIRST_CONTACT);
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deleteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteFirstCommand.equals(null));
+
+        // different contact -> returns false
+        assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index targetIndex = Index.fromOneBased(1);
+        DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(targetIndex);
+        String expected = DeleteWithChildrenCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        assertEquals(expected, deleteCommand.toString());
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show no one.
+     */
+    private void showNoContact(Model model) {
+        model.updateFilteredContactList(p -> false);
+
+        assertTrue(model.getFilteredContactList().isEmpty());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/DeleteWithChildrenCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteWithChildrenCommandTest.java
@@ -35,7 +35,7 @@ public class DeleteWithChildrenCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_unlinkedOrganizationSuccess() {
-        Contact contactToDelete = model.getFilteredContactList()
+        Contact contactToDelete = model.getDisplayedContactList()
                 .get(INDEX_UNLINKED_ORGANIZATION.getZeroBased());
         DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(INDEX_UNLINKED_ORGANIZATION);
 
@@ -51,7 +51,7 @@ public class DeleteWithChildrenCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_unlinkedRecruiterSuccess() {
-        Contact contactToDelete = model.getFilteredContactList()
+        Contact contactToDelete = model.getDisplayedContactList()
                 .get(INDEX_UNLINKED_RECRUITER.getZeroBased());
         DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(INDEX_UNLINKED_RECRUITER);
 
@@ -67,7 +67,7 @@ public class DeleteWithChildrenCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_linkedOrganizationSuccess() {
-        Contact contactToDelete = model.getFilteredContactList()
+        Contact contactToDelete = model.getDisplayedContactList()
                 .get(INDEX_LINKED_ORGANIZATION.getZeroBased());
         DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(INDEX_LINKED_ORGANIZATION);
 
@@ -87,7 +87,7 @@ public class DeleteWithChildrenCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_linkedRecruiterSuccess() {
-        Contact contactToDelete = model.getFilteredContactList()
+        Contact contactToDelete = model.getDisplayedContactList()
                 .get(INDEX_LINKED_RECRUITER.getZeroBased());
         DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(INDEX_LINKED_RECRUITER);
 
@@ -107,7 +107,7 @@ public class DeleteWithChildrenCommandTest {
 
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredContactList().size() + 1);
+        Index outOfBoundIndex = Index.fromOneBased(model.getDisplayedContactList().size() + 1);
         DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(outOfBoundIndex);
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
@@ -117,7 +117,7 @@ public class DeleteWithChildrenCommandTest {
     public void execute_validIndexFilteredList_success() {
         showContactAtIndex(model, INDEX_FIRST_CONTACT);
 
-        Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        Contact contactToDelete = model.getDisplayedContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
         DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(INDEX_FIRST_CONTACT);
 
         String expectedMessage = String.format(DeleteWithChildrenCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
@@ -135,7 +135,7 @@ public class DeleteWithChildrenCommandTest {
     public void execute_validIndexFilteredList_unlinkedOrganizationSuccess() {
         showContactAtIndex(model, INDEX_UNLINKED_ORGANIZATION);
 
-        Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        Contact contactToDelete = model.getDisplayedContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
         DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(INDEX_FIRST_CONTACT);
 
         String expectedMessage = String.format(DeleteWithChildrenCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
@@ -153,7 +153,7 @@ public class DeleteWithChildrenCommandTest {
     public void execute_validIndexFilteredList_unlinkedRecruiterSuccess() {
         showContactAtIndex(model, INDEX_UNLINKED_RECRUITER);
 
-        Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        Contact contactToDelete = model.getDisplayedContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
         DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(INDEX_FIRST_CONTACT);
 
         String expectedMessage = String.format(DeleteWithChildrenCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
@@ -171,7 +171,7 @@ public class DeleteWithChildrenCommandTest {
     public void execute_validIndexFilteredList_linkedOrganizationSuccess() {
         showContactAtIndex(model, INDEX_LINKED_ORGANIZATION);
 
-        Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        Contact contactToDelete = model.getDisplayedContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
         DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(INDEX_FIRST_CONTACT);
 
         String expectedMessage = String.format(DeleteWithChildrenCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
@@ -193,7 +193,7 @@ public class DeleteWithChildrenCommandTest {
     public void execute_validIndexFilteredList_linkedRecruiterSuccess() {
         showContactAtIndex(model, INDEX_LINKED_RECRUITER);
 
-        Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        Contact contactToDelete = model.getDisplayedContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
         DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(INDEX_FIRST_CONTACT);
 
         String expectedMessage = String.format(DeleteWithChildrenCommand.MESSAGE_DELETE_CONTACT_SUCCESS,
@@ -260,6 +260,6 @@ public class DeleteWithChildrenCommandTest {
     private void showNoContact(Model model) {
         model.updateFilteredContactList(p -> false);
 
-        assertTrue(model.getFilteredContactList().isEmpty());
+        assertTrue(model.getDisplayedContactList().isEmpty());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteWithChildrenCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteWithChildrenCommandTest.java
@@ -34,7 +34,7 @@ public class DeleteWithChildrenCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
-    public void execute_validIndexUnfilteredList_unlinkedOrganization_success() {
+    public void execute_validIndexUnfilteredList_unlinkedOrganizationSuccess() {
         Contact contactToDelete = model.getFilteredContactList()
                 .get(INDEX_UNLINKED_ORGANIZATION.getZeroBased());
         DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(INDEX_UNLINKED_ORGANIZATION);
@@ -50,7 +50,7 @@ public class DeleteWithChildrenCommandTest {
     }
 
     @Test
-    public void execute_validIndexUnfilteredList_unlinkedRecruiter_success() {
+    public void execute_validIndexUnfilteredList_unlinkedRecruiterSuccess() {
         Contact contactToDelete = model.getFilteredContactList()
                 .get(INDEX_UNLINKED_RECRUITER.getZeroBased());
         DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(INDEX_UNLINKED_RECRUITER);
@@ -66,7 +66,7 @@ public class DeleteWithChildrenCommandTest {
     }
 
     @Test
-    public void execute_validIndexUnfilteredList_linkedOrganization_success() {
+    public void execute_validIndexUnfilteredList_linkedOrganizationSuccess() {
         Contact contactToDelete = model.getFilteredContactList()
                 .get(INDEX_LINKED_ORGANIZATION.getZeroBased());
         DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(INDEX_LINKED_ORGANIZATION);
@@ -86,7 +86,7 @@ public class DeleteWithChildrenCommandTest {
     }
 
     @Test
-    public void execute_validIndexUnfilteredList_linkedRecruiter_success() {
+    public void execute_validIndexUnfilteredList_linkedRecruiterSuccess() {
         Contact contactToDelete = model.getFilteredContactList()
                 .get(INDEX_LINKED_RECRUITER.getZeroBased());
         DeleteWithChildrenCommand deleteCommand = new DeleteWithChildrenCommand(INDEX_LINKED_RECRUITER);
@@ -132,7 +132,7 @@ public class DeleteWithChildrenCommandTest {
     }
 
     @Test
-    public void execute_validIndexFilteredList_unlinkedOrganization_success() {
+    public void execute_validIndexFilteredList_unlinkedOrganizationSuccess() {
         showContactAtIndex(model, INDEX_UNLINKED_ORGANIZATION);
 
         Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
@@ -150,7 +150,7 @@ public class DeleteWithChildrenCommandTest {
     }
 
     @Test
-    public void execute_validIndexFilteredList_unlinkedRecruiter_success() {
+    public void execute_validIndexFilteredList_unlinkedRecruiterSuccess() {
         showContactAtIndex(model, INDEX_UNLINKED_RECRUITER);
 
         Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
@@ -168,7 +168,7 @@ public class DeleteWithChildrenCommandTest {
     }
 
     @Test
-    public void execute_validIndexFilteredList_linkedOrganization_success() {
+    public void execute_validIndexFilteredList_linkedOrganizationSuccess() {
         showContactAtIndex(model, INDEX_LINKED_ORGANIZATION);
 
         Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
@@ -190,7 +190,7 @@ public class DeleteWithChildrenCommandTest {
     }
 
     @Test
-    public void execute_validIndexFilteredList_linkedRecruiter_success() {
+    public void execute_validIndexFilteredList_linkedRecruiterSuccess() {
         showContactAtIndex(model, INDEX_LINKED_RECRUITER);
 
         Contact contactToDelete = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -44,7 +44,7 @@ public class EditCommandTest {
 
         Contact contactInFilteredList = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
         Contact editedContact = new ContactBuilder(contactInFilteredList).withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_CONTACT,
+        EditCommand editCommand = new EditCommand(contactInFilteredList.getId(),
                 new EditContactDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS,

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -69,7 +69,7 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_unlinkedOrganization_allFieldsSpecifiedUnfilteredList_success() {
+    public void execute_allFieldsSpecifiedUnfilteredList_unlinkedOrganizationSuccess() {
         Organization editedContact = new OrganizationBuilder(SMU)
                 .withId(VALID_ID_AMY).build();
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder(editedContact).build();
@@ -86,7 +86,7 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_unlinkedRecruiter_allFieldsSpecifiedUnfilteredList_success() {
+    public void execute_allFieldsSpecifiedUnfilteredList_unlinkedRecruiterSuccess() {
         Recruiter editedContact = new RecruiterBuilder(RICHARD)
                 .withId(VALID_ID_AMY).build();
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder(editedContact).build();
@@ -103,7 +103,7 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_linkedOrganization_allFieldsSpecifiedUnfilteredList_success() {
+    public void execute_allFieldsSpecifiedUnfilteredList_linkedOrganizationSuccess() {
         Organization originalOrganization = NUS;
         Organization editedOrganization = new OrganizationBuilder(originalOrganization)
                 .withId(VALID_ID_AMY).build();
@@ -125,7 +125,7 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_linkedRecruiter_allFieldsSpecifiedUnfilteredList_success() {
+    public void execute_allFieldsSpecifiedUnfilteredList_linkedRecruiterSuccess() {
         Recruiter editedRecruiter = new RecruiterBuilder(RYAN)
                 .withId(VALID_ID_AMY).build();
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder(editedRecruiter).build();
@@ -146,7 +146,7 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_linkedOrganization_someFieldsSpecifiedUnfilteredList_success() {
+    public void execute_someFieldsSpecifiedUnfilteredList_linkedOrganizationSuccess() {
         Organization originalOrganization = NUS;
         Organization editedOrganization = new OrganizationBuilder(originalOrganization)
                 .withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
@@ -171,7 +171,7 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_linkedRecruiter_someFieldsSpecifiedUnfilteredList_success() {
+    public void execute_someFieldsSpecifiedUnfilteredList_linkedRecruiterSuccess() {
         Recruiter editedRecruiter = new RecruiterBuilder(RYAN)
                 .withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
                 .withTags(VALID_TAG_HUSBAND).build();
@@ -195,7 +195,7 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_linkedOrganization_noFieldsSpecifiedUnfilteredList_success() {
+    public void execute_noFieldsSpecifiedUnfilteredList_linkedOrganizationSuccess() {
         EditCommand editCommand = new EditCommand(INDEX_LINKED_ORGANIZATION, new EditContactDescriptor());
         Contact editedContact = model.getFilteredContactList().get(INDEX_LINKED_ORGANIZATION.getZeroBased());
 
@@ -208,7 +208,7 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_linkedRecruiter_noFieldsSpecifiedUnfilteredList_success() {
+    public void execute_noFieldsSpecifiedUnfilteredList_linkedRecruiterSuccess() {
         EditCommand editCommand = new EditCommand(INDEX_LINKED_RECRUITER, new EditContactDescriptor());
         Contact editedRecruiter = model.getFilteredContactList().get(INDEX_LINKED_RECRUITER.getZeroBased());
 
@@ -224,7 +224,7 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_linkedOrganization_filteredList_success() {
+    public void execute_filteredList_linkedOrganizationSuccess() {
         showContactAtIndex(model, INDEX_LINKED_ORGANIZATION);
 
         Contact contactInFilteredList = model.getFilteredContactList()
@@ -249,7 +249,7 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_linkedRecruiter_filteredList_success() {
+    public void execute_filteredList_linkedRecruiterSuccess() {
         showContactAtIndex(model, INDEX_LINKED_RECRUITER);
 
         Contact contactInFilteredList = model.getFilteredContactList()

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -79,7 +79,7 @@ public class EditCommandTest {
                 .format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS, Messages.format(editedContact));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setContact(model.getFilteredContactList()
+        expectedModel.setContact(model.getDisplayedContactList()
                 .get(INDEX_UNLINKED_ORGANIZATION.getZeroBased()), editedContact);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
@@ -96,7 +96,7 @@ public class EditCommandTest {
                 .format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS, Messages.format(editedContact));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setContact(model.getFilteredContactList()
+        expectedModel.setContact(model.getDisplayedContactList()
                 .get(INDEX_UNLINKED_RECRUITER.getZeroBased()), editedContact);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
@@ -114,7 +114,7 @@ public class EditCommandTest {
                 .format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS, Messages.format(editedOrganization));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setContact(model.getFilteredContactList()
+        expectedModel.setContact(model.getDisplayedContactList()
                 .get(INDEX_LINKED_ORGANIZATION.getZeroBased()), editedOrganization);
         for (Contact child : originalOrganization.getChildren(expectedModel)) {
             expectedModel.setContact(child,
@@ -135,7 +135,7 @@ public class EditCommandTest {
                 .format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS, Messages.format(editedRecruiter));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setContact(model.getFilteredContactList()
+        expectedModel.setContact(model.getDisplayedContactList()
                 .get(INDEX_LINKED_RECRUITER.getZeroBased()), editedRecruiter);
 
         Contact parentContact = editedRecruiter.getParent().orElse(null);
@@ -160,7 +160,7 @@ public class EditCommandTest {
                 .format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS, Messages.format(editedOrganization));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setContact(model.getFilteredContactList()
+        expectedModel.setContact(model.getDisplayedContactList()
                 .get(INDEX_LINKED_ORGANIZATION.getZeroBased()), editedOrganization);
         for (Contact child : originalOrganization.getChildren(expectedModel)) {
             expectedModel.setContact(child,
@@ -184,7 +184,7 @@ public class EditCommandTest {
                 .format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS, Messages.format(editedRecruiter));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setContact(model.getFilteredContactList()
+        expectedModel.setContact(model.getDisplayedContactList()
                 .get(INDEX_LINKED_RECRUITER.getZeroBased()), editedRecruiter);
 
         Contact parentContact = editedRecruiter.getParent().orElse(null);
@@ -197,7 +197,7 @@ public class EditCommandTest {
     @Test
     public void execute_noFieldsSpecifiedUnfilteredList_linkedOrganizationSuccess() {
         EditCommand editCommand = new EditCommand(INDEX_LINKED_ORGANIZATION, new EditContactDescriptor());
-        Contact editedContact = model.getFilteredContactList().get(INDEX_LINKED_ORGANIZATION.getZeroBased());
+        Contact editedContact = model.getDisplayedContactList().get(INDEX_LINKED_ORGANIZATION.getZeroBased());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS,
                 Messages.format(editedContact));
@@ -210,7 +210,7 @@ public class EditCommandTest {
     @Test
     public void execute_noFieldsSpecifiedUnfilteredList_linkedRecruiterSuccess() {
         EditCommand editCommand = new EditCommand(INDEX_LINKED_RECRUITER, new EditContactDescriptor());
-        Contact editedRecruiter = model.getFilteredContactList().get(INDEX_LINKED_RECRUITER.getZeroBased());
+        Contact editedRecruiter = model.getDisplayedContactList().get(INDEX_LINKED_RECRUITER.getZeroBased());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS,
                 Messages.format(editedRecruiter));
@@ -227,7 +227,7 @@ public class EditCommandTest {
     public void execute_filteredList_linkedOrganizationSuccess() {
         showContactAtIndex(model, INDEX_LINKED_ORGANIZATION);
 
-        Contact contactInFilteredList = model.getFilteredContactList()
+        Contact contactInFilteredList = model.getDisplayedContactList()
                 .get(INDEX_FIRST_CONTACT.getZeroBased());
         Organization editedOrganization = new OrganizationBuilder((Organization) contactInFilteredList)
                 .withName(VALID_NAME_BOB).build();
@@ -238,7 +238,7 @@ public class EditCommandTest {
                 Messages.format(editedOrganization));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setContact(model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased()),
+        expectedModel.setContact(model.getDisplayedContactList().get(INDEX_FIRST_CONTACT.getZeroBased()),
                 editedOrganization);
         for (Contact child : contactInFilteredList.getChildren(expectedModel)) {
             expectedModel.setContact(child,
@@ -252,7 +252,7 @@ public class EditCommandTest {
     public void execute_filteredList_linkedRecruiterSuccess() {
         showContactAtIndex(model, INDEX_LINKED_RECRUITER);
 
-        Contact contactInFilteredList = model.getFilteredContactList()
+        Contact contactInFilteredList = model.getDisplayedContactList()
                 .get(INDEX_FIRST_CONTACT.getZeroBased());
         Recruiter editedContact = new RecruiterBuilder((Recruiter) contactInFilteredList)
                 .withName(VALID_NAME_BOB).build();
@@ -263,7 +263,7 @@ public class EditCommandTest {
                 Messages.format(editedContact));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setContact(model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased()),
+        expectedModel.setContact(model.getDisplayedContactList().get(INDEX_FIRST_CONTACT.getZeroBased()),
                 editedContact);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -148,8 +148,9 @@ public class EditCommandTest {
     @Test
     public void execute_duplicateContactFilteredListWithId_failure() {
         // edit contact in filtered list into a duplicate in address book
+        Contact contactToEdit = model.getAddressBook().getContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
         Contact contactInList = model.getAddressBook().getContactList().get(INDEX_SECOND_CONTACT.getZeroBased());
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_CONTACT,
+        EditCommand editCommand = new EditCommand(contactToEdit.getId(),
                 new EditContactDescriptorBuilder(contactInList).build());
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_CONTACT);

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -5,15 +5,24 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showContactAtIndex;
+import static seedu.address.testutil.TypicalContacts.NUS;
+import static seedu.address.testutil.TypicalContacts.RICHARD;
+import static seedu.address.testutil.TypicalContacts.RYAN;
+import static seedu.address.testutil.TypicalContacts.SMU;
 import static seedu.address.testutil.TypicalContacts.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CONTACT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_LINKED_ORGANIZATION;
+import static seedu.address.testutil.TypicalIndexes.INDEX_LINKED_RECRUITER;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_CONTACT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_UNLINKED_ORGANIZATION;
+import static seedu.address.testutil.TypicalIndexes.INDEX_UNLINKED_RECRUITER;
 
 import org.junit.jupiter.api.Test;
 
@@ -25,9 +34,12 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.contact.Contact;
+import seedu.address.model.contact.Organization;
 import seedu.address.model.contact.Recruiter;
+import seedu.address.model.contact.Type;
 import seedu.address.testutil.ContactBuilder;
 import seedu.address.testutil.EditContactDescriptorBuilder;
+import seedu.address.testutil.OrganizationBuilder;
 import seedu.address.testutil.RecruiterBuilder;
 
 /**
@@ -57,51 +69,202 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_allFieldsSpecifiedUnfilteredList_success() {
-        Contact editedContact = new ContactBuilder().build();
+    public void execute_unlinkedOrganization_allFieldsSpecifiedUnfilteredList_success() {
+        Organization editedContact = new OrganizationBuilder(SMU)
+                .withId(VALID_ID_AMY).build();
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder(editedContact).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_CONTACT, descriptor);
+        EditCommand editCommand = new EditCommand(INDEX_UNLINKED_ORGANIZATION, descriptor);
 
         String expectedMessage = String
                 .format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS, Messages.format(editedContact));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setContact(model.getFilteredContactList().get(0), editedContact);
+        expectedModel.setContact(model.getFilteredContactList()
+                .get(INDEX_UNLINKED_ORGANIZATION.getZeroBased()), editedContact);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
-    public void execute_someFieldsSpecifiedUnfilteredList_success() {
-        Index indexLastContact = Index.fromOneBased(model.getFilteredContactList().size());
-        Contact lastContact = model.getFilteredContactList().get(indexLastContact.getZeroBased());
+    public void execute_unlinkedRecruiter_allFieldsSpecifiedUnfilteredList_success() {
+        Recruiter editedContact = new RecruiterBuilder(RICHARD)
+                .withId(VALID_ID_AMY).build();
+        EditContactDescriptor descriptor = new EditContactDescriptorBuilder(editedContact).build();
+        EditCommand editCommand = new EditCommand(INDEX_UNLINKED_RECRUITER, descriptor);
 
-        RecruiterBuilder contactInList = new RecruiterBuilder((Recruiter) lastContact);
-        Recruiter editedContact = contactInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
+        String expectedMessage = String
+                .format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS, Messages.format(editedContact));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setContact(model.getFilteredContactList()
+                .get(INDEX_UNLINKED_RECRUITER.getZeroBased()), editedContact);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_linkedOrganization_allFieldsSpecifiedUnfilteredList_success() {
+        Organization originalOrganization = NUS;
+        Organization editedOrganization = new OrganizationBuilder(originalOrganization)
+                .withId(VALID_ID_AMY).build();
+        EditContactDescriptor descriptor = new EditContactDescriptorBuilder(editedOrganization).build();
+        EditCommand editCommand = new EditCommand(INDEX_LINKED_ORGANIZATION, descriptor);
+
+        String expectedMessage = String
+                .format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS, Messages.format(editedOrganization));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setContact(model.getFilteredContactList()
+                .get(INDEX_LINKED_ORGANIZATION.getZeroBased()), editedOrganization);
+        for (Contact child : originalOrganization.getChildren(expectedModel)) {
+            expectedModel.setContact(child,
+                    new RecruiterBuilder((Recruiter) child).withOrganization(editedOrganization).build());
+        }
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_linkedRecruiter_allFieldsSpecifiedUnfilteredList_success() {
+        Recruiter editedRecruiter = new RecruiterBuilder(RYAN)
+                .withId(VALID_ID_AMY).build();
+        EditContactDescriptor descriptor = new EditContactDescriptorBuilder(editedRecruiter).build();
+        EditCommand editCommand = new EditCommand(INDEX_LINKED_RECRUITER, descriptor);
+
+        String expectedMessage = String
+                .format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS, Messages.format(editedRecruiter));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setContact(model.getFilteredContactList()
+                .get(INDEX_LINKED_RECRUITER.getZeroBased()), editedRecruiter);
+
+        Contact parentContact = editedRecruiter.getParent().orElse(null);
+        assert parentContact != null && parentContact.getType() == Type.ORGANIZATION;
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertTrue(parentContact.getChildren(model).contains(editedRecruiter));
+    }
+
+    @Test
+    public void execute_linkedOrganization_someFieldsSpecifiedUnfilteredList_success() {
+        Organization originalOrganization = NUS;
+        Organization editedOrganization = new OrganizationBuilder(originalOrganization)
+                .withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
                 .withTags(VALID_TAG_HUSBAND).build();
+        EditContactDescriptor descriptor = new EditContactDescriptorBuilder()
+                .withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
+                .withTags(VALID_TAG_HUSBAND).build();
+        EditCommand editCommand = new EditCommand(INDEX_LINKED_ORGANIZATION, descriptor);
 
-        EditContactDescriptor descriptor = new EditContactDescriptorBuilder().withName(VALID_NAME_BOB)
-                .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
-        EditCommand editCommand = new EditCommand(indexLastContact, descriptor);
-
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS,
-                Messages.format(editedContact));
+        String expectedMessage = String
+                .format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS, Messages.format(editedOrganization));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setContact(lastContact, editedContact);
+        expectedModel.setContact(model.getFilteredContactList()
+                .get(INDEX_LINKED_ORGANIZATION.getZeroBased()), editedOrganization);
+        for (Contact child : originalOrganization.getChildren(expectedModel)) {
+            expectedModel.setContact(child,
+                    new RecruiterBuilder((Recruiter) child).withOrganization(editedOrganization).build());
+        }
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
-    public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_CONTACT, new EditContactDescriptor());
-        Contact editedContact = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+    public void execute_linkedRecruiter_someFieldsSpecifiedUnfilteredList_success() {
+        Recruiter editedRecruiter = new RecruiterBuilder(RYAN)
+                .withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
+                .withTags(VALID_TAG_HUSBAND).build();
+        EditContactDescriptor descriptor = new EditContactDescriptorBuilder()
+                .withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
+                .withTags(VALID_TAG_HUSBAND).build();
+        EditCommand editCommand = new EditCommand(INDEX_LINKED_RECRUITER, descriptor);
+
+        String expectedMessage = String
+                .format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS, Messages.format(editedRecruiter));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setContact(model.getFilteredContactList()
+                .get(INDEX_LINKED_RECRUITER.getZeroBased()), editedRecruiter);
+
+        Contact parentContact = editedRecruiter.getParent().orElse(null);
+        assert parentContact != null && parentContact.getType() == Type.ORGANIZATION;
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertTrue(parentContact.getChildren(model).contains(editedRecruiter));
+    }
+
+    @Test
+    public void execute_linkedOrganization_noFieldsSpecifiedUnfilteredList_success() {
+        EditCommand editCommand = new EditCommand(INDEX_LINKED_ORGANIZATION, new EditContactDescriptor());
+        Contact editedContact = model.getFilteredContactList().get(INDEX_LINKED_ORGANIZATION.getZeroBased());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS,
                 Messages.format(editedContact));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_linkedRecruiter_noFieldsSpecifiedUnfilteredList_success() {
+        EditCommand editCommand = new EditCommand(INDEX_LINKED_RECRUITER, new EditContactDescriptor());
+        Contact editedRecruiter = model.getFilteredContactList().get(INDEX_LINKED_RECRUITER.getZeroBased());
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS,
+                Messages.format(editedRecruiter));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        Contact parentContact = editedRecruiter.getParent().orElse(null);
+        assert parentContact != null && parentContact.getType() == Type.ORGANIZATION;
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertTrue(parentContact.getChildren(model).contains(editedRecruiter));
+    }
+
+    @Test
+    public void execute_linkedOrganization_filteredList_success() {
+        showContactAtIndex(model, INDEX_LINKED_ORGANIZATION);
+
+        Contact contactInFilteredList = model.getFilteredContactList()
+                .get(INDEX_FIRST_CONTACT.getZeroBased());
+        Organization editedOrganization = new OrganizationBuilder((Organization) contactInFilteredList)
+                .withName(VALID_NAME_BOB).build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_CONTACT,
+                new EditContactDescriptorBuilder().withName(VALID_NAME_BOB).build());
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS,
+                Messages.format(editedOrganization));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setContact(model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased()),
+                editedOrganization);
+        for (Contact child : contactInFilteredList.getChildren(expectedModel)) {
+            expectedModel.setContact(child,
+                    new RecruiterBuilder((Recruiter) child).withOrganization(editedOrganization).build());
+        }
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_linkedRecruiter_filteredList_success() {
+        showContactAtIndex(model, INDEX_LINKED_RECRUITER);
+
+        Contact contactInFilteredList = model.getFilteredContactList()
+                .get(INDEX_FIRST_CONTACT.getZeroBased());
+        Recruiter editedContact = new RecruiterBuilder((Recruiter) contactInFilteredList)
+                .withName(VALID_NAME_BOB).build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_CONTACT,
+                new EditContactDescriptorBuilder(editedContact).build());
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS,
+                Messages.format(editedContact));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setContact(model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased()),
+                editedContact);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/model/contact/RecruiterTest.java
+++ b/src/test/java/seedu/address/model/contact/RecruiterTest.java
@@ -2,6 +2,7 @@ package seedu.address.model.contact;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
@@ -48,6 +49,20 @@ class RecruiterTest {
         // id differs in case, all other attributes same -> returns false
         editedRyan = new RecruiterBuilder(RYAN).withId(RYAN.getId().value.toUpperCase()).build();
         assertFalse(RYAN.isSameContact(editedRyan));
+    }
+
+    @Test
+    public void recruiterLinkedToValidOrganization() {
+        Recruiter linkedRecruiter = new RecruiterBuilder(RYAN).withOrganization(NTU).build();
+        assertEquals(linkedRecruiter.getOrganization().orElse(null), NTU);
+        assertEquals(linkedRecruiter.getOrganizationId().orElse(null), NTU.getId());
+    }
+
+    @Test
+    public void recruiterLinkedToNoOrganization() {
+        Recruiter unlinkedRecruiter = new RecruiterBuilder(RYAN).withOrganization(null).build();
+        assertNull(unlinkedRecruiter.getOrganization().orElse(null));
+        assertNull(unlinkedRecruiter.getOrganizationId().orElse(null));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/ContactBuilder.java
+++ b/src/test/java/seedu/address/testutil/ContactBuilder.java
@@ -118,7 +118,7 @@ public class ContactBuilder {
     }
 
     public Contact build() {
-        return new Contact(name, id, phone, email, url, address, tags);
+        return new Contact(name, id, phone, email, url, address, tags, null);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/EditContactDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditContactDescriptorBuilder.java
@@ -8,8 +8,13 @@ import seedu.address.logic.commands.EditCommand.EditContactDescriptor;
 import seedu.address.model.contact.Address;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.Email;
+import seedu.address.model.contact.Id;
 import seedu.address.model.contact.Name;
+import seedu.address.model.contact.Organization;
 import seedu.address.model.contact.Phone;
+import seedu.address.model.contact.Recruiter;
+import seedu.address.model.contact.Type;
+import seedu.address.model.contact.Url;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -36,8 +41,21 @@ public class EditContactDescriptorBuilder {
         descriptor.setId(contact.getId());
         descriptor.setPhone(contact.getPhone().orElse(null));
         descriptor.setEmail(contact.getEmail().orElse(null));
+        descriptor.setUrl(contact.getUrl().orElse(null));
         descriptor.setAddress(contact.getAddress().orElse(null));
         descriptor.setTags(contact.getTags());
+
+        if (contact.getType() == Type.ORGANIZATION) {
+            Organization organization = (Organization) contact;
+            descriptor.setStatus(organization.getStatus().orElse(null));
+            descriptor.setPosition(organization.getPosition().orElse(null));
+            descriptor.setOid(null);
+        } else if (contact.getType() == Type.RECRUITER) {
+            Recruiter recruiter = (Recruiter) contact;
+            descriptor.setStatus(null);
+            descriptor.setPosition(null);
+            descriptor.setOid(recruiter.getOrganizationId().orElse(null));
+        }
     }
 
     /**
@@ -45,6 +63,14 @@ public class EditContactDescriptorBuilder {
      */
     public EditContactDescriptorBuilder withName(String name) {
         descriptor.setName(new Name(name));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Id} of the {@code EditContactDescriptor} that we are building.
+     */
+    public EditContactDescriptorBuilder withId(String id) {
+        descriptor.setId(new Id(id));
         return this;
     }
 
@@ -61,6 +87,14 @@ public class EditContactDescriptorBuilder {
      */
     public EditContactDescriptorBuilder withEmail(String email) {
         descriptor.setEmail(new Email(email));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Url} of the {@code EditContactDescriptor} that we are building.
+     */
+    public EditContactDescriptorBuilder withUrl(String url) {
+        descriptor.setUrl(new Url(url));
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalContacts.java
+++ b/src/test/java/seedu/address/testutil/TypicalContacts.java
@@ -142,7 +142,7 @@ public class TypicalContacts {
             .withUrl("www.rex.com")
             .withAddress("80 Stamford Rd")
             .withTags("cool", "resourceful")
-            .withOrganization(SMU)
+            .withOrganization(NTU)
             .build();
 
     public static final Recruiter RICHARD = new RecruiterBuilder()
@@ -152,7 +152,7 @@ public class TypicalContacts {
             .withEmail("richlee@smu.edu.sg")
             .withUrl("www.richard_lion_heart.com")
             .withAddress("80 Stamford Rd")
-            .withOrganization(SMU)
+            .withOrganization(null)
             .build();
 
     // Manually added

--- a/src/test/java/seedu/address/testutil/TypicalContacts.java
+++ b/src/test/java/seedu/address/testutil/TypicalContacts.java
@@ -86,7 +86,6 @@ public class TypicalContacts {
             .withTags("computing", "worldClass")
             .withStatus("Applied")
             .withPosition("Research Assistant")
-            .withRids("soc-rec_ryan")
             .build();
 
     public static final Organization NTU = new OrganizationBuilder()

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -9,7 +9,7 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_CONTACT = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_CONTACT = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_CONTACT = Index.fromOneBased(3);
-    public static final Index INDEX_LINKED_ORGANIZATION = Index.fromOneBased(4);
+    public static final Index INDEX_LINKED_ORGANIZATION = Index.fromOneBased(3);
     public static final Index INDEX_LINKED_RECRUITER = Index.fromOneBased(6);
     public static final Index INDEX_UNLINKED_ORGANIZATION = Index.fromOneBased(5);
     public static final Index INDEX_UNLINKED_RECRUITER = Index.fromOneBased(9);

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -9,4 +9,8 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_CONTACT = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_CONTACT = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_CONTACT = Index.fromOneBased(3);
+    public static final Index INDEX_LINKED_ORGANIZATION = Index.fromOneBased(4);
+    public static final Index INDEX_LINKED_RECRUITER = Index.fromOneBased(6);
+    public static final Index INDEX_UNLINKED_ORGANIZATION = Index.fromOneBased(5);
+    public static final Index INDEX_UNLINKED_RECRUITER = Index.fromOneBased(9);
 }


### PR DESCRIPTION
This PR aims to

- [x] Implement a general parent-child relationship at the `Contact` level
- [x] Fix delete recursive
- [x] Fix delete to remove recruiters' links to the organization
- [x] Fix edit such that when an organization's Id is changed, the change is reflected in the recruiters' oids as well
- [x] Add tests to check if delete and deleteWithChildren handles the linkage properly (Does not include delete by Id)
- [x] Add tests to check if edit changes the recruiters' link to the updated organization (Does not include edit by Id)