### PR TITLE
Fix issue with detecting duplicate contacts when adding

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -86,6 +86,13 @@ public class AddressBook implements ReadOnlyAddressBook {
         contacts.remove(key);
     }
 
+    /**
+     * Returns true if a contact with the same identity as {@code contact} exists in the address book.
+     */
+    public boolean hasContact(Contact contact) {
+        requireNonNull(contact);
+        return contacts.contains(contact);
+    }
 
     //// util methods
 

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -32,12 +32,4 @@ public interface ReadOnlyAddressBook {
         return null;
     }
 
-    /**
-     * Returns true if a contact with the same identity as {@code contact} exists in the address book.
-     */
-    default boolean hasContact(Contact contact) {
-        requireNonNull(contact);
-        return getContactList().contains(contact);
-    }
-
 }

--- a/src/test/java/seedu/address/logic/commands/AddOrganizationCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddOrganizationCommandIntegrationTest.java
@@ -11,7 +11,6 @@ import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.Organization;
 import seedu.address.testutil.OrganizationBuilder;
 
@@ -54,19 +53,22 @@ public class AddOrganizationCommandIntegrationTest {
 
     @Test
     public void execute_duplicateOrganization_throwsCommandException() {
-        Contact contactInList = model.getAddressBook().getContactList().get(3);
-        Organization organizationInList = (Organization) contactInList;
+        Organization organizationInList = (Organization) model.getAddressBook().getContactList().get(2);
+        Organization duplicateOrganization = new OrganizationBuilder()
+                .withId(organizationInList.getId().value).build();
+
+        // Ensure that AddOrganizationCommand checks duplicate contact BY ID ONLY.
         AddOrganizationCommand addCommand = new AddOrganizationCommand(
-                organizationInList.getName(),
-                organizationInList.getId(),
-                organizationInList.getPhone().orElse(null),
-                organizationInList.getEmail().orElse(null),
-                organizationInList.getUrl().orElse(null),
-                organizationInList.getAddress().orElse(null),
-                organizationInList.getTags(),
-                organizationInList.getStatus().orElse(null),
-                organizationInList.getPosition().orElse(null),
-                organizationInList.getRecruiterIds()
+                duplicateOrganization.getName(),
+                duplicateOrganization.getId(),
+                duplicateOrganization.getPhone().orElse(null),
+                duplicateOrganization.getEmail().orElse(null),
+                duplicateOrganization.getUrl().orElse(null),
+                duplicateOrganization.getAddress().orElse(null),
+                duplicateOrganization.getTags(),
+                duplicateOrganization.getStatus().orElse(null),
+                duplicateOrganization.getPosition().orElse(null),
+                duplicateOrganization.getRecruiterIds()
         );
         assertCommandFailure(addCommand, model, AddOrganizationCommand.MESSAGE_DUPLICATE_CONTACT);
     }

--- a/src/test/java/seedu/address/logic/commands/AddRecruiterCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddRecruiterCommandIntegrationTest.java
@@ -11,7 +11,6 @@ import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.Organization;
 import seedu.address.model.contact.Recruiter;
 import seedu.address.testutil.OrganizationBuilder;
@@ -82,17 +81,19 @@ public class AddRecruiterCommandIntegrationTest {
 
     @Test
     public void execute_duplicateRecruiter_throwsCommandException() {
-        Contact contactInList = model.getAddressBook().getContactList().get(5);
-        Recruiter recruiterInList = (Recruiter) contactInList;
+        Recruiter recruiterInList = (Recruiter) model.getAddressBook().getContactList().get(5);
+        Recruiter duplicateRecruiter = new RecruiterBuilder().withId(recruiterInList.getId().value).build();
+
+        // Ensure that AddRecruiterCommand checks duplicate contact BY ID ONLY.
         AddRecruiterCommand addCommand = new AddRecruiterCommand(
-                recruiterInList.getName(),
-                recruiterInList.getId(),
-                recruiterInList.getPhone().orElse(null),
-                recruiterInList.getEmail().orElse(null),
-                recruiterInList.getUrl().orElse(null),
-                recruiterInList.getAddress().orElse(null),
-                recruiterInList.getTags(),
-                recruiterInList.getOrganizationId().orElse(null)
+                duplicateRecruiter.getName(),
+                duplicateRecruiter.getId(),
+                duplicateRecruiter.getPhone().orElse(null),
+                duplicateRecruiter.getEmail().orElse(null),
+                duplicateRecruiter.getUrl().orElse(null),
+                duplicateRecruiter.getAddress().orElse(null),
+                duplicateRecruiter.getTags(),
+                duplicateRecruiter.getOrganizationId().orElse(null)
         );
         assertCommandFailure(addCommand, model, AddRecruiterCommand.MESSAGE_DUPLICATE_CONTACT);
     }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalContacts.ALICE;
@@ -71,10 +72,17 @@ public class AddressBookTest {
     }
 
     @Test
-    public void hasContact_contactWithSameIdentityFieldsInAddressBook_returnsFalse() {
+    public void hasContact_contactWithSameIdInAddressBook_returnsTrue() {
         addressBook.addContact(ALICE);
-        Contact editedAlice = new ContactBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
-                .build();
+        Contact editedAlice = new ContactBuilder(ALICE).withAddress(VALID_ADDRESS_BOB)
+                .withTags(VALID_TAG_HUSBAND).build();
+        assertTrue(addressBook.hasContact(editedAlice));
+    }
+
+    @Test
+    public void hasContact_contactWithDifferentIdInAddressBook_returnsFalse() {
+        addressBook.addContact(ALICE);
+        Contact editedAlice = new ContactBuilder(ALICE).withId(VALID_ID_BOB).build();
         assertFalse(addressBook.hasContact(editedAlice));
     }
 


### PR DESCRIPTION
Moving `hasContact` to the `ReadOnlyAddressBook` interface caused it to reference an `ObservableList` instead of a `UniqueContactList`. Hence the `contains` method used is different. This caused contacts to be compared by strict equality instead of Id, thus triggering an error.