### PR TITLE
Fix edit command to not re-link `Recruiters` if duplicate is detected

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -131,7 +131,7 @@ public class AddCommand extends Command {
             + MESSAGE_ORGANIZATION_USAGE + "\n\n"
             + MESSAGE_RECRUITER_USAGE;
 
-    public static final String MESSAGE_SUCCESS = "New contact added: %1$s";
+    public static final String MESSAGE_SUCCESS = "New %s added: %s";
     public static final String MESSAGE_DUPLICATE_CONTACT = "This contact already exists in the address book";
 
     private static final Logger logger = LogsCenter.getLogger(AddCommand.class);
@@ -173,7 +173,7 @@ public class AddCommand extends Command {
         }
 
         model.addContact(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd.getType(), Messages.format(toAdd)));
     }
 
     protected Contact createContact() {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -177,6 +177,10 @@ public class EditCommand extends Command {
         if (!contactToEdit.isSameContact(editedContact) && model.hasContact(editedContact)) {
             throw new CommandException(MESSAGE_DUPLICATE_CONTACT);
         }
+
+        if (editedContact.getType() == Type.ORGANIZATION) {
+            updateLinkedRecruiters(model, (Organization) contactToEdit, (Organization) editedContact);
+        }
         model.setContact(contactToEdit, editedContact);
         model.updateFilteredContactList(PREDICATE_SHOW_ALL_CONTACTS);
         return new CommandResult(String.format(MESSAGE_EDIT_CONTACT_SUCCESS, Messages.format(editedContact)));
@@ -213,42 +217,47 @@ public class EditCommand extends Command {
             Position updatedPosition = editContactDescriptor.getPosition()
                     .orElse(((Organization) contactToEdit).getPosition().orElse(null));
 
-            Organization updatedOrganization = new Organization(updatedName, updatedId, updatedPhone, updatedEmail,
+            return new Organization(updatedName, updatedId, updatedPhone, updatedEmail,
                     updatedUrl, updatedAddress, updatedTags, updatedStatus, updatedPosition, null);
-
-            // Updates all recruiters linked to the old organization to link to the updated one.
-            List<Contact> childrenContacts = contactToEdit.getChildren(model);
-            for (Contact child : childrenContacts) {
-                assert child.getType() == Type.RECRUITER;
-                Recruiter updatedRecruiter = new Recruiter(
-                        child.getName(), child.getId(), child.getPhone().orElse(null),
-                        child.getEmail().orElse(null), child.getUrl().orElse(null),
-                        child.getAddress().orElse(null), child.getTags(), updatedOrganization
-                );
-                model.setContact(child, updatedRecruiter);
-            }
-
-            return updatedOrganization;
 
         } else if (contactToEdit.getType() == Type.RECRUITER) {
             Optional<Id> updatedOid = editContactDescriptor
                     .getOrganizationId()
                     .or(() -> ((Recruiter) contactToEdit).getOrganizationId());
 
-            Organization updatedOrganization = (Organization) updatedOid.map(model::getContactById)
+            Organization linkedOrganization = (Organization) updatedOid.map(model::getContactById)
                     .filter(c -> c.getType() == Type.ORGANIZATION)
                     .orElse(null);
 
-            if (updatedOid.isPresent() && updatedOrganization == null) {
+            if (updatedOid.isPresent() && linkedOrganization == null) {
                 throw new CommandException(MESSAGE_INVALID_ORGANIZATION);
             }
 
             return new Recruiter(updatedName, updatedId, updatedPhone, updatedEmail, updatedUrl,
-                    updatedAddress, updatedTags, updatedOrganization);
+                    updatedAddress, updatedTags, linkedOrganization);
         }
 
         return new Contact(updatedName, updatedId, updatedPhone, updatedEmail, updatedUrl, updatedAddress,
                 updatedTags, null);
+    }
+
+    /**
+     * Updates all recruiters linked to the {@code oldOrganization} to link to the {@code updatedOrganization}.
+     */
+    private static void updateLinkedRecruiters(Model model,
+                                               Organization oldOrganization,
+                                               Organization updatedOrganization) {
+        // Updates all recruiters linked to the old organization to link to the updated one.
+        List<Contact> childrenContacts = oldOrganization.getChildren(model);
+        for (Contact child : childrenContacts) {
+            assert child.getType() == Type.RECRUITER;
+            Recruiter updatedRecruiter = new Recruiter(
+                    child.getName(), child.getId(), child.getPhone().orElse(null),
+                    child.getEmail().orElse(null), child.getUrl().orElse(null),
+                    child.getAddress().orElse(null), child.getTags(), updatedOrganization
+            );
+            model.setContact(child, updatedRecruiter);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -86,6 +86,13 @@ public class AddressBook implements ReadOnlyAddressBook {
         contacts.remove(key);
     }
 
+    /**
+     * Returns true if a contact with the same identity as {@code contact} exists in the address book.
+     */
+    public boolean hasContact(Contact contact) {
+        requireNonNull(contact);
+        return contacts.contains(contact);
+    }
 
     //// util methods
 

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -32,12 +32,4 @@ public interface ReadOnlyAddressBook {
         return null;
     }
 
-    /**
-     * Returns true if a contact with the same identity as {@code contact} exists in the address book.
-     */
-    default boolean hasContact(Contact contact) {
-        requireNonNull(contact);
-        return getContactList().contains(contact);
-    }
-
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -44,7 +44,8 @@ public class AddCommandIntegrationTest {
         );
 
         assertCommandSuccess(addCommand, model,
-                String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(validContact)),
+                String.format(AddCommand.MESSAGE_SUCCESS,
+                        validContact.getType(), Messages.format(validContact)),
                 expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -73,7 +73,8 @@ public class AddCommandTest {
 
         CommandResult commandResult = addCommand.execute(modelStub);
 
-        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(validContact)),
+        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS,
+                        validContact.getType(), Messages.format(validContact)),
                 commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validContact), modelStub.contactsAdded);
     }

--- a/src/test/java/seedu/address/logic/commands/AddOrganizationCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddOrganizationCommandIntegrationTest.java
@@ -11,7 +11,6 @@ import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.Organization;
 import seedu.address.testutil.OrganizationBuilder;
 
@@ -54,19 +53,22 @@ public class AddOrganizationCommandIntegrationTest {
 
     @Test
     public void execute_duplicateOrganization_throwsCommandException() {
-        Contact contactInList = model.getAddressBook().getContactList().get(3);
-        Organization organizationInList = (Organization) contactInList;
+        Organization organizationInList = (Organization) model.getAddressBook().getContactList().get(2);
+        Organization duplicateOrganization = new OrganizationBuilder()
+                .withId(organizationInList.getId().value).build();
+
+        // Ensure that AddOrganizationCommand checks duplicate contact BY ID ONLY.
         AddOrganizationCommand addCommand = new AddOrganizationCommand(
-                organizationInList.getName(),
-                organizationInList.getId(),
-                organizationInList.getPhone().orElse(null),
-                organizationInList.getEmail().orElse(null),
-                organizationInList.getUrl().orElse(null),
-                organizationInList.getAddress().orElse(null),
-                organizationInList.getTags(),
-                organizationInList.getStatus().orElse(null),
-                organizationInList.getPosition().orElse(null),
-                organizationInList.getRecruiterIds()
+                duplicateOrganization.getName(),
+                duplicateOrganization.getId(),
+                duplicateOrganization.getPhone().orElse(null),
+                duplicateOrganization.getEmail().orElse(null),
+                duplicateOrganization.getUrl().orElse(null),
+                duplicateOrganization.getAddress().orElse(null),
+                duplicateOrganization.getTags(),
+                duplicateOrganization.getStatus().orElse(null),
+                duplicateOrganization.getPosition().orElse(null),
+                duplicateOrganization.getRecruiterIds()
         );
         assertCommandFailure(addCommand, model, AddOrganizationCommand.MESSAGE_DUPLICATE_CONTACT);
     }

--- a/src/test/java/seedu/address/logic/commands/AddOrganizationCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddOrganizationCommandIntegrationTest.java
@@ -47,7 +47,8 @@ public class AddOrganizationCommandIntegrationTest {
         );
 
         assertCommandSuccess(addCommand, model,
-                String.format(AddOrganizationCommand.MESSAGE_SUCCESS, Messages.format(validOrganization)),
+                String.format(AddOrganizationCommand.MESSAGE_SUCCESS,
+                        validOrganization.getType(), Messages.format(validOrganization)),
                 expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddOrganizationCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddOrganizationCommandTest.java
@@ -67,7 +67,8 @@ public class AddOrganizationCommandTest extends AddCommandTest {
 
         CommandResult commandResult = addCommand.execute(modelStub);
 
-        assertEquals(String.format(AddOrganizationCommand.MESSAGE_SUCCESS, Messages.format(validOrganization)),
+        assertEquals(String.format(AddOrganizationCommand.MESSAGE_SUCCESS,
+                        validOrganization.getType(), Messages.format(validOrganization)),
                 commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validOrganization), modelStub.contactsAdded);
     }

--- a/src/test/java/seedu/address/logic/commands/AddRecruiterCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddRecruiterCommandIntegrationTest.java
@@ -51,7 +51,8 @@ public class AddRecruiterCommandIntegrationTest {
         );
 
         assertCommandSuccess(addCommand, model,
-                String.format(AddRecruiterCommand.MESSAGE_SUCCESS, Messages.format(validRecruiter)),
+                String.format(AddRecruiterCommand.MESSAGE_SUCCESS,
+                        validRecruiter.getType(), Messages.format(validRecruiter)),
                 expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddRecruiterCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddRecruiterCommandIntegrationTest.java
@@ -11,7 +11,6 @@ import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.Organization;
 import seedu.address.model.contact.Recruiter;
 import seedu.address.testutil.OrganizationBuilder;
@@ -82,17 +81,19 @@ public class AddRecruiterCommandIntegrationTest {
 
     @Test
     public void execute_duplicateRecruiter_throwsCommandException() {
-        Contact contactInList = model.getAddressBook().getContactList().get(5);
-        Recruiter recruiterInList = (Recruiter) contactInList;
+        Recruiter recruiterInList = (Recruiter) model.getAddressBook().getContactList().get(5);
+        Recruiter duplicateRecruiter = new RecruiterBuilder().withId(recruiterInList.getId().value).build();
+
+        // Ensure that AddRecruiterCommand checks duplicate contact BY ID ONLY.
         AddRecruiterCommand addCommand = new AddRecruiterCommand(
-                recruiterInList.getName(),
-                recruiterInList.getId(),
-                recruiterInList.getPhone().orElse(null),
-                recruiterInList.getEmail().orElse(null),
-                recruiterInList.getUrl().orElse(null),
-                recruiterInList.getAddress().orElse(null),
-                recruiterInList.getTags(),
-                recruiterInList.getOrganizationId().orElse(null)
+                duplicateRecruiter.getName(),
+                duplicateRecruiter.getId(),
+                duplicateRecruiter.getPhone().orElse(null),
+                duplicateRecruiter.getEmail().orElse(null),
+                duplicateRecruiter.getUrl().orElse(null),
+                duplicateRecruiter.getAddress().orElse(null),
+                duplicateRecruiter.getTags(),
+                duplicateRecruiter.getOrganizationId().orElse(null)
         );
         assertCommandFailure(addCommand, model, AddRecruiterCommand.MESSAGE_DUPLICATE_CONTACT);
     }

--- a/src/test/java/seedu/address/logic/commands/AddRecruiterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddRecruiterCommandTest.java
@@ -63,7 +63,8 @@ public class AddRecruiterCommandTest extends AddCommandTest {
 
         CommandResult commandResult = addCommand.execute(modelStub);
 
-        assertEquals(String.format(AddRecruiterCommand.MESSAGE_SUCCESS, Messages.format(validRecruiter)),
+        assertEquals(String.format(AddRecruiterCommand.MESSAGE_SUCCESS,
+                        validRecruiter.getType(), Messages.format(validRecruiter)),
                 commandResult.getFeedbackToUser());
 
         assertEquals(Arrays.asList(validRecruiter), modelStub.contactsAdded);

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -103,6 +103,27 @@ public class EditCommandTest {
     }
 
     @Test
+    public void execute_duplicateLinkedOrganization_failure() {
+        Organization firstOrganization = (Organization) model.getDisplayedContactList()
+                .get(INDEX_LINKED_ORGANIZATION.getZeroBased());
+        Organization secondOrganization = (Organization) model.getDisplayedContactList()
+                .get(INDEX_UNLINKED_ORGANIZATION.getZeroBased());
+
+        Organization editedOrganization = new OrganizationBuilder(firstOrganization)
+                .withId(secondOrganization.getId().value).build();
+        EditContactDescriptor descriptor = new EditContactDescriptorBuilder(editedOrganization).build();
+        EditCommand editCommand = new EditCommand(INDEX_LINKED_ORGANIZATION, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_DUPLICATE_CONTACT,
+                Messages.format(editedOrganization));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        assertCommandFailure(editCommand, model, expectedMessage);
+        assertEquals(model, expectedModel);
+    }
+
+    @Test
     public void execute_allFieldsSpecifiedUnfilteredList_linkedOrganizationSuccess() {
         Organization originalOrganization = NUS;
         Organization editedOrganization = new OrganizationBuilder(originalOrganization)
@@ -110,8 +131,8 @@ public class EditCommandTest {
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder(editedOrganization).build();
         EditCommand editCommand = new EditCommand(INDEX_LINKED_ORGANIZATION, descriptor);
 
-        String expectedMessage = String
-                .format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS, Messages.format(editedOrganization));
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS,
+                Messages.format(editedOrganization));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setContact(model.getDisplayedContactList()

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalContacts.ALICE;
@@ -71,10 +72,17 @@ public class AddressBookTest {
     }
 
     @Test
-    public void hasContact_contactWithSameIdentityFieldsInAddressBook_returnsFalse() {
+    public void hasContact_contactWithSameIdInAddressBook_returnsTrue() {
         addressBook.addContact(ALICE);
-        Contact editedAlice = new ContactBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
-                .build();
+        Contact editedAlice = new ContactBuilder(ALICE).withAddress(VALID_ADDRESS_BOB)
+                .withTags(VALID_TAG_HUSBAND).build();
+        assertTrue(addressBook.hasContact(editedAlice));
+    }
+
+    @Test
+    public void hasContact_contactWithDifferentIdInAddressBook_returnsFalse() {
+        addressBook.addContact(ALICE);
+        Contact editedAlice = new ContactBuilder(ALICE).withId(VALID_ID_BOB).build();
         assertFalse(addressBook.hasContact(editedAlice));
     }
 


### PR DESCRIPTION
Currently, editing an organization's Id to an Id that exists within the address book will not prevent recruiters from being relinked to the new organization with this duplicate Id.

The expected behavior is that the recruiters' link to their parent organization does not change if the organization's Id is edited to a duplicate one.