### PR TITLE
Update autocomplete UI & UX

### DIFF
--- a/src/main/java/seedu/address/logic/autocomplete/AutocompleteGenerator.java
+++ b/src/main/java/seedu/address/logic/autocomplete/AutocompleteGenerator.java
@@ -51,23 +51,14 @@ public class AutocompleteGenerator {
     private final BiFunction<String, Model, Stream<String>> resultEvaluationFunction;
 
     /**
-     * Constructs an autocomplete generator based on the given set of reference full command strings.
-     */
-    public AutocompleteGenerator(Stream<String> referenceCommands) {
-        this(() -> referenceCommands);
-    }
-
-    /**
      * Constructs an autocomplete generator based on the given supplier of full command strings.
      */
     public AutocompleteGenerator(Supplier<Stream<String>> referenceCommandsSupplier) {
         resultEvaluationFunction = (partialCommand, model) -> {
-            if (partialCommand == null) {
-                return Stream.empty();
-            }
+            String input = partialCommand == null ? "" : partialCommand;
 
             return referenceCommandsSupplier.get()
-                    .filter(term -> StringUtil.isFuzzyMatch(partialCommand, term))
+                    .filter(term -> StringUtil.isFuzzyMatch(input, term))
                     .sorted(TEXT_FUZZY_MATCH_COMPARATOR.apply(partialCommand))
                     .distinct();
         };

--- a/src/main/java/seedu/address/logic/parser/AppParser.java
+++ b/src/main/java/seedu/address/logic/parser/AppParser.java
@@ -103,12 +103,12 @@ public class AppParser {
      */
     public AutocompleteGenerator parseCompletionGenerator(String userInput) {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
-        if (!matcher.matches()) {
+        if (!matcher.matches() && !userInput.isEmpty()) {
             return AutocompleteGenerator.NO_RESULTS;
         }
-        final String commandWord = matcher.group("commandWord");
+        final String commandWord = userInput.isEmpty() ? "" : matcher.group("commandWord");
 
-        logger.finest("Preparing autocomplete: " + userInput);
+        logger.finest("Preparing autocomplete: '" + userInput + "'");
 
         switch (commandWord) {
         case AddCommand.COMMAND_WORD:
@@ -137,7 +137,7 @@ public class AppParser {
 
         default:
             // Not a valid command. Return autocompletion results based on all the known command names.
-            return new AutocompleteGenerator(
+            return new AutocompleteGenerator(() ->
                     Command.getCommandWords(Stream.of(
                             AddCommand.class, ApplyCommand.class, DeleteCommand.class, EditCommand.class,
                             ListCommand.class, FindCommand.class, HelpCommand.class,

--- a/src/main/java/seedu/address/ui/AutocompleteTextField.java
+++ b/src/main/java/seedu/address/ui/AutocompleteTextField.java
@@ -76,8 +76,8 @@ public class AutocompleteTextField extends TextField {
         this.autocompletePopup = new ContextMenu();
 
         // Setup autocompletion popup menu UI updates
-        this.textProperty().addListener(e -> updatePopupState());
-        this.focusedProperty().addListener(e -> updatePopupState());
+        this.textProperty().addListener(e -> refreshPopupState());
+        this.focusedProperty().addListener(e -> refreshPopupState());
 
         // Setup autocompletion undo data cleanup
         this.textProperty().addListener((e, oldValue, newValue) -> updateUndoHistoryState(oldValue, newValue));
@@ -138,7 +138,7 @@ public class AutocompleteTextField extends TextField {
         // Update the view and cursor location
         this.requestFocus();
         this.end();
-        this.updatePopupState();
+        this.refreshPopupState();
     }
 
     /**
@@ -167,7 +167,7 @@ public class AutocompleteTextField extends TextField {
         // Update the view and cursor location
         this.requestFocus();
         this.end();
-        this.updatePopupState();
+        this.refreshPopupState();
         return true;
     }
 
@@ -181,7 +181,7 @@ public class AutocompleteTextField extends TextField {
     /**
      * Updates the state of the popup indicating the autocompletion entries.
      */
-    protected void updatePopupState() {
+    public void refreshPopupState() {
         String text = getText();
         if (text.isEmpty() || !isFocused()) {
             autocompletePopup.hide();

--- a/src/main/java/seedu/address/ui/AutocompleteTextField.java
+++ b/src/main/java/seedu/address/ui/AutocompleteTextField.java
@@ -1,18 +1,23 @@
 package seedu.address.ui;
 
+import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Stack;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
 import javafx.geometry.Side;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.CustomMenuItem;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
+import javafx.scene.layout.HBox;
 
 /**
  * A text field capable of displaying and performing autocomplete.
@@ -179,29 +184,98 @@ public class AutocompleteTextField extends TextField {
     }
 
     /**
+     * Hides the autocomplete popup menu if it is visible.
+     * This is temporary and may be shown again if the user types anything,
+     * or if {@link #refreshPopupState()} is invoked.
+     */
+    public void hidePopup() {
+        this.autocompletePopup.hide();
+    }
+
+    /**
+     * Shows the autocomplete popup menu if there are contents to show but it is not yet visible.
+     * This is equivalent to calling {@link #refreshPopupState()}, since the popup is visible by default when there
+     * are elements.
+     */
+    public void showPopup() {
+        this.refreshPopupState();
+    }
+
+    /**
      * Updates the state of the popup indicating the autocompletion entries.
      */
     public void refreshPopupState() {
         String text = getText();
-        if (text.isEmpty() || !isFocused()) {
+        if (!isFocused() || popupLimit <= 0) {
             autocompletePopup.hide();
             return;
         }
 
+        // Obtain the list of completions
+        List<String> completions = completionGenerator.apply(text)
+                .limit(popupLimit + 1) // (+ 1 so we can tell if it exceeds the limit)
+                .collect(Collectors.toList());
+
+        // Obtain the length of the prefix part of the completion strings that can be truncated
+        int hidableCompletionPrefixLength = completions.stream()
+                .min(Comparator.comparingInt(String::length))
+                .map(String::length)
+                .map(l -> Math.max(0, l - 48)) // Keep the last 48 characters in view
+                .orElse(0);
+
+        // Populate the menu items
         List<CustomMenuItem> menuItems = new LinkedList<>();
+        for (int i = 0; i < completions.size(); i++) {
 
-        completionGenerator.apply(text)
-                .limit(popupLimit)
-                .forEachOrdered(autocompletedString -> {
-                    Label entryLabel = new Label(autocompletedString);
-                    CustomMenuItem item = new CustomMenuItem(entryLabel, false);
-                    item.setOnAction(e -> triggerImmediateAutocompletionUsingResult(autocompletedString));
-                    menuItems.add(item);
-                });
+            // Create the relevant labels
+            String completion = completions.get(i);
+            String[] completionParts = splitIntoAutocompletionComponents(getText(), completion);
 
+            String prefixMatchPart = truncateFrontWithEllipsis(completionParts[0], hidableCompletionPrefixLength);
+            String postfixCompletionPart = completionParts[1];
+
+            Label completionLabelFront = new Label(prefixMatchPart);
+            Label completionLabelBack = new Label(postfixCompletionPart);
+
+            completionLabelFront.getStyleClass().add("completion-prefix");
+            completionLabelBack.getStyleClass().add("completion-data");
+
+            // Create the horizontal box
+            HBox completionBox = new HBox(completionLabelFront, completionLabelBack);
+            completionBox.getStyleClass().add("autocomplete-box");
+            completionBox.setPadding(new Insets(0, 8, 0, 8));
+            completionBox.setAlignment(Pos.BASELINE_CENTER);
+
+            // Create the context menu item
+            CustomMenuItem item = new CustomMenuItem(completionBox, false);
+            item.setOnAction(e -> triggerImmediateAutocompletionUsingResult(completion));
+            menuItems.add(item);
+
+            // Handle special case styling
+            if (i == 0) {
+                // Special Case 1: First completion option
+                Label completionHint = new Label("[Press TAB or SPACE to autocomplete]");
+                completionHint.getStyleClass().add("completion-hint");
+                completionHint.setPadding(new Insets(0, 8, 0, 8));
+
+                completionBox.getStyleClass().add("primary");
+                completionBox.getChildren().add(completionHint);
+
+            } else if (i >= popupLimit) {
+                // Special Case 2: Options exceeding limit and not first element
+                completionLabelFront.setText("... (more options hidden)");
+                completionLabelBack.setText(null);
+                item.setDisable(true);
+                break; // Stop further processing immediately - only one of this should be displayed.
+
+            }
+        }
+
+        // Replace the current menu items with the new set
         autocompletePopup.getItems().clear();
         autocompletePopup.getItems().addAll(menuItems);
 
+        // Update popup display state accordingly
         if (menuItems.size() > 0) {
             if (!autocompletePopup.isShowing()) {
                 autocompletePopup.show(AutocompleteTextField.this, Side.BOTTOM, 0, 0);
@@ -226,6 +300,54 @@ public class AutocompleteTextField extends TextField {
         ) {
             autocompleteHistory.pop();
         }
+    }
+
+    /**
+     * Splits the given autocomplete result by the closest prefix matched phrase and the autocompleted result.
+     *
+     * <p>
+     * For example, providing the input {@code "abc def 1234"} with autocompletion {@code "abc def 12345 ghi"}
+     * would yield a split of {@code new String[] { "abc def", "12345 ghi" }}
+     * </p>
+     *
+     * @return an array of length 2 that contains the (prefix part, autocompletion part).
+     */
+    private String[] splitIntoAutocompletionComponents(String input, String autocompletionResult) {
+        int secondPartIndex = 0;
+
+        // Step 1: Find the index beyond the prefix match.
+        while (secondPartIndex < input.length()
+                && secondPartIndex < autocompletionResult.length()
+                && input.charAt(secondPartIndex) == autocompletionResult.charAt(secondPartIndex)) {
+            secondPartIndex++;
+        }
+
+        // Step 2: Backtrack till a space is found.
+        while (secondPartIndex - 1 >= 0
+                && autocompletionResult.charAt(secondPartIndex - 1) != ' ') {
+            secondPartIndex--;
+        }
+
+        // Step 3: Split by the given index, if possible.
+        if (secondPartIndex >= 0 && secondPartIndex <= autocompletionResult.length()) {
+            return new String[] {
+                    autocompletionResult.substring(0, secondPartIndex),
+                    autocompletionResult.substring(secondPartIndex),
+            };
+        } else {
+            return new String[] { autocompletionResult, "" };
+        }
+    }
+
+    /**
+     * Truncates the given string by the given {@code truncateAmount} of characters at the front, and adds
+     * leading ellipsis. It returns just the ellipsis if the number of characters truncated exceeds the string length.
+     */
+    private String truncateFrontWithEllipsis(String str, int truncateAmount) {
+        if (truncateAmount <= 0) {
+            return str;
+        }
+        return truncateAmount >= str.length() ? "..." : "..." + str.substring(truncateAmount);
     }
 
 }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -40,51 +40,20 @@ public class CommandBox extends UiPart<Region> {
         this.completionGenerator = completionGenerator;
 
         assert commandTextField != null;
-        commandTextField.setCompletionGenerator(completionGenerator);
 
-        commandTextField.setOnKeyPressed(this::handleKeyEvent);
-        commandTextField.setOnKeyReleased(this::handleKeyEvent);
-        commandTextField.setOnKeyTyped(this::handleKeyEvent);
+        // Setup completion results and hints
+        commandTextField.setCompletionGenerator(completionGenerator);
+        commandTextField.setAutocompleteHintString("[Press TAB or SPACE to autocomplete]");
+
+        // Setup UI events
+        commandTextField.setOnAction(e -> this.handleCommandEntered());
 
         commandTextField.addEventFilter(KeyEvent.KEY_PRESSED, this::handleKeyFilter);
         commandTextField.addEventFilter(KeyEvent.KEY_RELEASED, this::handleKeyFilter);
         commandTextField.addEventFilter(KeyEvent.KEY_TYPED, this::handleKeyFilter);
 
-        // calls #setStyleToDefault() whenever there is a change to the text of the command box.
+        // Sets the style to default whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
-    }
-
-
-    /**
-     * Handles the key event of a textbox.
-     */
-    @FXML
-    private void handleKeyEvent(KeyEvent keyEvent) {
-
-        // Note:
-        //   These captures keystrokes at different KeyEvent due to weird JavaFX quirks not actually delivering
-        //   all events at all situations.
-
-        if (keyEvent.getEventType() == KeyEvent.KEY_PRESSED
-                && keyEvent.getCode() == KeyCode.ENTER) {
-
-            logger.fine("Received key ENTER");
-
-            this.handleCommandEntered();
-
-        } else if (keyEvent.getEventType() == KeyEvent.KEY_PRESSED
-                && keyEvent.getCode() == KeyCode.TAB) {
-
-            logger.fine("Intercepted TAB key");
-
-            keyEvent.consume(); // consume by default
-            commandTextField.requestFocus(); // revert to this focus in case (otherwise tab changes focus)
-            commandTextField.end();
-
-            this.handleCommandAutocompleted(keyEvent);
-
-            commandTextField.refreshPopupState();
-        }
     }
 
     /**
@@ -92,27 +61,40 @@ public class CommandBox extends UiPart<Region> {
      */
     @FXML
     private void handleKeyFilter(KeyEvent keyEvent) {
-        if (this.commandTextField.getCaretPosition() < this.commandTextField.getText().length()) {
-            // Caret not at end. Autocomplete not applicable using standard keyboard intercepts.
-            return;
-        }
+        boolean isTextCaretAtEnd =
+                this.commandTextField.getCaretPosition() == this.commandTextField.getText().length()
+                    && this.commandTextField.getSelectedText().isEmpty();
+        boolean isKeyTyped = keyEvent.getEventType() == KeyEvent.KEY_TYPED;
+        boolean isKeyPressed = keyEvent.getEventType() == KeyEvent.KEY_PRESSED;
 
         // Note:
-        //   These captures keystrokes at different KeyEvent due to weird JavaFX quirks not actually delivering
-        //   all events at all situations.
+        //   These captures keystrokes at different KeyEvent types, as there some events are captured by
+        //   other elements, and hence not all events are delivered in all situations.
 
-        if (keyEvent.getEventType() == KeyEvent.KEY_TYPED
-                && Objects.equals(keyEvent.getCharacter(), " ")) {
-
+        if (isKeyTyped && isTextCaretAtEnd && Objects.equals(keyEvent.getCharacter(), " ")) {
             logger.fine("Intercepted SPACE typed at end");
             this.handleCommandAutocompleted(keyEvent);
 
-        } else if (keyEvent.getEventType() == KeyEvent.KEY_PRESSED
-                && keyEvent.getCode() == KeyCode.BACK_SPACE) {
 
+        } else if (isKeyPressed && isTextCaretAtEnd && keyEvent.getCode() == KeyCode.BACK_SPACE) {
             logger.fine("Intercepted BACKSPACE typed at end");
             this.handleCommandUndoAutocomplete(keyEvent);
 
+
+        } else if (isKeyPressed && keyEvent.getCode() == KeyCode.TAB) {
+            logger.fine("Intercepted TAB key");
+
+            keyEvent.consume(); // Consume to prevent element focus change.
+
+            // There are two cases for TAB:
+            //  - Case 1: Autocomplete popup shown --> Triggers autocomplete result
+            //  - Case 2: Autocomplete popup not shown --> Tries to make autocomplete popup visible
+
+            if (commandTextField.isPopupVisible()) {
+                this.handleCommandAutocompleted(keyEvent);
+            } else {
+                commandTextField.showPopup();
+            }
         }
     }
 
@@ -153,6 +135,9 @@ public class CommandBox extends UiPart<Region> {
         boolean hasAutocompletedResult = commandTextField.triggerImmediateAutocompletion();
         if (hasAutocompletedResult) {
             keyEvent.consume();
+
+            commandTextField.requestFocus();
+            commandTextField.end();
         }
     }
 
@@ -165,6 +150,9 @@ public class CommandBox extends UiPart<Region> {
         boolean hasUndoneCompletion = commandTextField.undoLastImmediateAutocompletion();
         if (hasUndoneCompletion) {
             keyEvent.consume();
+
+            commandTextField.requestFocus();
+            commandTextField.end();
         }
     }
 

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -65,10 +65,11 @@ public class CommandBox extends UiPart<Region> {
         //   These captures keystrokes at different KeyEvent due to weird JavaFX quirks not actually delivering
         //   all events at all situations.
 
-        if (keyEvent.getEventType() == KeyEvent.KEY_RELEASED
+        if (keyEvent.getEventType() == KeyEvent.KEY_PRESSED
                 && keyEvent.getCode() == KeyCode.ENTER) {
 
             logger.fine("Received key ENTER");
+
             this.handleCommandEntered();
 
         } else if (keyEvent.getEventType() == KeyEvent.KEY_PRESSED
@@ -120,16 +121,25 @@ public class CommandBox extends UiPart<Region> {
      */
     private void handleCommandEntered() {
         String commandText = commandTextField.getText();
-        if (commandText.equals("")) {
+
+        if (commandText.isBlank()) {
+            // Ignore and reset blank (whitespace-only or empty) inputs
+            commandTextField.setText("");
             return;
         }
 
         try {
+            // Process the command
             commandExecutor.execute(commandText);
+
+            // Once successful, reset the text field
             commandTextField.setText("");
             commandTextField.requestFocus();
+            commandTextField.hidePopup();
+
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
+            commandTextField.hidePopup();
         }
     }
 

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -328,6 +328,25 @@
     -fx-text-fill: white;
 }
 
+.autocomplete-box.primary {
+    -fx-background-color: #ffffff22;
+}
+
+.autocomplete-box .completion-prefix {
+    -fx-font-size: 12pt;
+    -fx-text-fill: #ffffff88;
+}
+
+.autocomplete-box .completion-data {
+    -fx-font-size: 12pt;
+    -fx-text-fill: #ffffffff;
+}
+
+.autocomplete-box .completion-hint {
+    -fx-font-size: 7pt;
+    -fx-text-fill: #ffffff88;
+}
+
 #filterField, #personListPanel, #personWebpage {
     -fx-effect: innershadow(gaussian, black, 10, 0, 0, 0);
 }

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -159,6 +159,8 @@ public class StringUtilTest {
         assertTrue(StringUtil.isFuzzyMatch("b12", "abc123"));
 
         // Boundaries
+        assertTrue(StringUtil.isFuzzyMatch("", "abc123"));
+
         assertTrue(StringUtil.isFuzzyMatch("a", "abc123"));
         assertTrue(StringUtil.isFuzzyMatch("3", "abc123"));
 

--- a/src/test/java/seedu/address/logic/autocomplete/AutocompleteGeneratorTest.java
+++ b/src/test/java/seedu/address/logic/autocomplete/AutocompleteGeneratorTest.java
@@ -40,7 +40,7 @@ public class AutocompleteGeneratorTest {
 
         assertEquals(
                 resultList,
-                new AutocompleteGenerator(sourceList.stream())
+                new AutocompleteGenerator(sourceList::stream)
                         .generateCompletions("ad")
                         .collect(Collectors.toList())
         );


### PR DESCRIPTION
There were some usability issues with autocomplete. It has been updated with the following changes:

1. Autocompletion results are now shown immediately on any text field focus, including when the command field is completely blank.
2. Autocompletion results are now dismissed immediately when a command is executed, a command failed, the text field loses focus (e.g., mouse click elsewhere), or if **ESC** is pressed.
3. Autocomplete undo no longer leaves a trailing space (since you can now cancel autocomplete with **ESC**, this is no longer necessary).
4. If the autocompletion popup is currently dismissed, pressing **TAB** will now re-display the popup without actually autocompleting it.
5. If the autocompletion popup is currently dismissed, pressing **SPACE** will no longer autocomplete any data - it instead types the "` `" as usual.
6. Autocomplete UI now highlights the completion terms in a stronger font color, making it easy to glance what text will be completed.
7. Autocomplete UI is now truncated at the prefix when the command is extremely long.
8. Autocomplete UI now hints that pressing the **TAB** or **SPACE** key will invoke the first completion.
9. Autocomplete UI now hints if there are more results than the maximum (10) which have been omitted from the displayed results.